### PR TITLE
feat(eval): add model eval harness and `miii doctor`

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,34 @@ Every sensitive operation is gated by a permission system — you approve what t
 
 ---
 
+## Checking your setup
+
+miii is model-agnostic — but not every local model can actually drive an agent. A model that can't emit clean tool calls will chat at you instead of editing files. `miii doctor` tells you which of *your* installed models are up to the job, before you waste time wondering why nothing happens.
+
+```bash
+miii doctor                     # check every local model (from `ollama list`)
+miii doctor qwen2.5-coder:7b    # check one model
+miii doctor gemma4:e4b grep     # one model, only scenarios matching "grep"
+```
+
+It runs the real agent against a handful of concrete tasks (edit a file, read-and-answer, create a file, locate a definition) and checks the *outcome* — did the file actually change, was the answer right — then prints a verdict per model:
+
+```
+=== qwen3-coder ===
+PASS  edit-exact-string   ...
+PASS  read-then-answer    ...
+PASS  create-new-file     ...
+PASS  grep-locate         ...
+  → qwen3-coder: 4/4 — ready
+
+=== gemma4:e4b ===
+  → gemma4:e4b: 1/4 — not recommended — weak tool-calling
+```
+
+With more than one model it also prints a compatibility matrix (`+` pass, `.` fail). Cloud models are skipped by default; name one explicitly to include it. If a model comes back `marginal` or `not recommended`, pull a stronger coding model and try again.
+
+---
+
 ## Architecture
 
 ```mermaid
@@ -196,11 +224,25 @@ npm run dev
 ```
 
 ```bash
-npm run build   # production build
-npm run start   # run built output
+npm run build       # production build
+npm run start       # run built output
+npm run typecheck   # type-check src + eval
+npm run eval        # run the eval harness as a CI / regression gate
 ```
 
----
+The eval harness lives in `eval/` and powers `miii doctor`. As `npm run eval` it doubles as a regression gate — it exits non-zero if any model fails any scenario, so a prompt or tool change that regresses a baseline model is caught in CI. Same engine, two doors: `miii doctor` for users checking their setup, `npm run eval` for maintainers gating changes.
+
+### Testing the `miii` command against your local changes
+
+The global `miii` command points at whatever was last installed with `npm install -g miii-agent` — **not** your working tree. After editing source, the global binary is stale, so `miii` (and `miii doctor`) will run the old code and may appear to ignore your changes (e.g. printing the wrong model). Two ways to run your local build:
+
+```bash
+node dist/cli.js doctor <model>   # run the freshly built output directly
+# — or —
+npm run build && npm link         # point the global `miii` at this repo
+```
+
+`npm link` symlinks the global `miii` to `dist/cli.js` in this repo, so each `npm run build` is picked up automatically. Restore the published version later with `npm install -g miii-agent`. Note: `npm run dev` / `npm run start` always run the current source and never have this staleness problem.
 
 ## Project Status
 

--- a/eval/run.ts
+++ b/eval/run.ts
@@ -1,0 +1,101 @@
+import { runScenario } from './runner.js'
+import { scenarios } from './scenarios.js'
+import { listModels } from '../src/ollama/client.js'
+import type { Result, Scenario } from './types.js'
+
+// Usage (standalone or via `miii eval`):
+//   [models] [scenarioNameSubstring]
+//     models: comma list (gemma4:e4b,llama3.1:8b), or "all" for every
+//             installed model, or omitted -> $MIII_EVAL_MODEL / "all".
+//     scenarioNameSubstring: run only matching scenarios.
+// Leading dashes are stripped, so `--gemma4:e4b` == `gemma4:e4b`.
+
+function pad(s: string, n: number): string {
+  return s.length >= n ? s.slice(0, n) : s + ' '.repeat(n - s.length)
+}
+
+async function resolveModels(modelsArg: string): Promise<string[]> {
+  if (modelsArg !== 'all') return modelsArg.split(',').map((m) => m.trim()).filter(Boolean)
+  // Skip cloud models by default — they're slow/billed and the harness targets
+  // local models. Opt back in by naming them explicitly.
+  return (await listModels()).filter((m) => !m.includes('cloud'))
+}
+
+/** Turn a pass-rate into a plain-language verdict for `miii doctor`. */
+function verdict(passed: number, total: number): string {
+  const ratio = total === 0 ? 0 : passed / total
+  if (ratio === 1) return 'ready'
+  if (ratio >= 0.5) return 'marginal — some tasks fail'
+  return 'not recommended — weak tool-calling'
+}
+
+async function runModel(model: string, picked: Scenario[]): Promise<Result[]> {
+  console.log(`\n=== ${model} ===`)
+  const results: Result[] = []
+  // Sequential — runner chdirs the process; concurrency would corrupt cwd.
+  for (const s of picked) {
+    const r = await runScenario(model, s)
+    results.push(r)
+    const mark = r.pass ? 'PASS' : 'FAIL'
+    const detail = r.pass ? '' : `  ${r.reason ?? r.error ?? ''}`
+    console.log(
+      `${mark}  ${pad(r.name, 22)} ${pad(`${r.toolCalls} calls`, 9)} ` +
+        `${pad(`${r.evalTokens} tok`, 11)} ${pad(`${r.durationMs}ms`, 8)}${detail}`,
+    )
+  }
+  const passed = results.filter((r) => r.pass).length
+  console.log(`  → ${model}: ${passed}/${picked.length} — ${verdict(passed, picked.length)}`)
+  return results
+}
+
+function printMatrix(models: string[], picked: Scenario[], grid: Map<string, Result[]>) {
+  const w = Math.max(...picked.map((s) => s.name.length), 3) + 1
+  const modelW = Math.max(...models.map((m) => m.length), 5) + 1
+  // Header row: scenario names.
+  console.log('\nMatrix\n')
+  let header = pad('', modelW)
+  for (const s of picked) header += pad(s.name.slice(0, w - 1), w)
+  console.log(header + ' score')
+  for (const m of models) {
+    let row = pad(m, modelW)
+    const rs = grid.get(m) ?? []
+    let passed = 0
+    for (const s of picked) {
+      const r = rs.find((x) => x.name === s.name)
+      const cell = !r ? '?' : r.pass ? '+' : '.'
+      if (r?.pass) passed++
+      row += pad(cell, w)
+    }
+    row += ` ${passed}/${picked.length}`
+    console.log(row)
+  }
+  console.log('\n  + pass   . fail   ? not run')
+}
+
+/** Run the eval suite. `args` = [models?, scenarioFilter?]; returns exit code. */
+export async function runEval(args: string[]): Promise<number> {
+  const strip = (s: string | undefined) => (s ?? '').replace(/^-+/, '')
+  const modelsArg = strip(args[0]) || process.env.MIII_EVAL_MODEL || 'all'
+  const filter = strip(args[1])
+
+  const picked = filter ? scenarios.filter((s) => s.name.includes(filter)) : scenarios
+  if (picked.length === 0) {
+    console.error(`No scenarios match "${filter}"`)
+    return 1
+  }
+  const models = await resolveModels(modelsArg)
+  if (models.length === 0) {
+    console.error('No models to run.')
+    return 1
+  }
+
+  console.log(`models: ${models.length}   scenarios: ${picked.length}`)
+  const grid = new Map<string, Result[]>()
+  for (const model of models) grid.set(model, await runModel(model, picked))
+
+  if (models.length > 1) printMatrix(models, picked, grid)
+
+  // Non-zero if any model failed any scenario — useful for CI gating.
+  const allPass = [...grid.values()].every((rs) => rs.every((r) => r.pass))
+  return allPass ? 0 : 1
+}

--- a/eval/runner.ts
+++ b/eval/runner.ts
@@ -1,0 +1,84 @@
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'fs'
+import { dirname, join } from 'path'
+import { tmpdir } from 'os'
+import { runAgent } from '../src/agent/loop.js'
+import type { PermissionContext } from '../src/permissions/policy.js'
+import type { Scenario, Result } from './types.js'
+
+// Eval runs unattended: every tool call is auto-approved. The permission layer
+// is exercised by unit tests, not here — here we measure task completion.
+const autoYes: PermissionContext = { ask: async () => 'yes' }
+
+/**
+ * Run one scenario end-to-end against a real model and return its metrics.
+ *
+ * Tools confine to process.cwd() (see src/tools/paths.ts), so we chdir into a
+ * throwaway temp dir per scenario, run, then restore. Sequential only — chdir is
+ * process-global; never run two scenarios concurrently.
+ */
+export async function runScenario(model: string, s: Scenario): Promise<Result> {
+  const dir = mkdtempSync(join(tmpdir(), 'miii-eval-'))
+  const prevCwd = process.cwd()
+
+  for (const [rel, content] of Object.entries(s.files ?? {})) {
+    const abs = join(dir, rel)
+    mkdirSync(dirname(abs), { recursive: true })
+    writeFileSync(abs, content, 'utf-8')
+  }
+
+  const r: Result = {
+    name: s.name,
+    pass: false,
+    toolCalls: 0,
+    promptTokens: 0,
+    evalTokens: 0,
+    durationMs: 0,
+  }
+  const start = Date.now()
+
+  let finalText = ''
+  try {
+    process.chdir(dir)
+    const gen = runAgent({
+      model,
+      cwd: dir,
+      history: [],
+      userText: s.prompt,
+      permissions: autoYes,
+    })
+    for await (const ev of gen) {
+      if (ev.type === 'tool-use') r.toolCalls++
+      else if (ev.type === 'text-delta') finalText += ev.text
+      else if (ev.type === 'turn-end' && ev.stop_reason === 'tool_use') finalText = ''
+      else if (ev.type === 'done') {
+        r.promptTokens = ev.prompt_tokens
+        r.evalTokens = ev.eval_tokens
+      } else if (ev.type === 'error') r.error = ev.message
+    }
+  } catch (err) {
+    r.error = err instanceof Error ? err.message : String(err)
+  } finally {
+    process.chdir(prevCwd)
+  }
+  r.durationMs = Date.now() - start
+
+  // A loop-level error (model missing, repetition kill, stream fail) is an
+  // automatic fail — never let a check false-pass over a broken run.
+  if (r.error) {
+    r.reason = `loop error: ${r.error}`
+    rmSync(dir, { recursive: true, force: true })
+    return r
+  }
+
+  // Assertion runs against the temp dir while it still exists.
+  try {
+    const verdict = await s.check(dir, finalText.trim())
+    if (verdict === true) r.pass = true
+    else r.reason = typeof verdict === 'string' ? verdict : 'check returned false'
+  } catch (err) {
+    r.reason = `check threw: ${err instanceof Error ? err.message : String(err)}`
+  }
+
+  rmSync(dir, { recursive: true, force: true })
+  return r
+}

--- a/eval/scenarios.ts
+++ b/eval/scenarios.ts
@@ -1,0 +1,59 @@
+import { readFileSync, existsSync } from 'fs'
+import { join } from 'path'
+import type { Scenario } from './types.js'
+
+const read = (dir: string, f: string) =>
+  existsSync(join(dir, f)) ? readFileSync(join(dir, f), 'utf-8') : null
+
+// Keep scenarios small, deterministic, and outcome-checked. One capability each.
+// A scenario should fail loudly if the agent drifts, over-edits, or stops early.
+export const scenarios: Scenario[] = [
+  {
+    name: 'edit-exact-string',
+    prompt: 'In config.js, change the port from 3000 to 8080. Change nothing else.',
+    files: { 'config.js': 'export const port = 3000\nexport const host = "localhost"\n' },
+    check: (dir) => {
+      const out = read(dir, 'config.js')
+      if (out == null) return 'config.js missing'
+      if (!out.includes('8080')) return 'port not changed to 8080'
+      if (out.includes('3000')) return 'old port 3000 still present'
+      if (!out.includes('host = "localhost"')) return 'unrelated line damaged'
+      return true
+    },
+  },
+  {
+    name: 'read-then-answer',
+    prompt: 'What is the value of the MAX_RETRIES constant in limits.js? Reply with just the number.',
+    files: { 'limits.js': 'export const MAX_RETRIES = 7\n' },
+    check: (dir, finalText) => {
+      if (read(dir, 'limits.js')?.includes('MAX_RETRIES = 7') !== true)
+        return 'agent mutated a read-only task'
+      if (!/\b7\b/.test(finalText)) return `answer missing "7": ${JSON.stringify(finalText)}`
+      return true
+    },
+  },
+  {
+    name: 'create-new-file',
+    prompt: 'Create a file named greeting.txt containing exactly the text: hello world',
+    check: (dir) => {
+      const out = read(dir, 'greeting.txt')
+      if (out == null) return 'greeting.txt not created'
+      if (out.trim() !== 'hello world') return `wrong content: ${JSON.stringify(out)}`
+      return true
+    },
+  },
+  {
+    name: 'grep-locate',
+    prompt: 'Which file defines a function called computeTax? Reply with just the filename.',
+    files: {
+      'a.js': 'export function formatDate() {}\n',
+      'b.js': 'export function computeTax(x) { return x * 0.1 }\n',
+      'c.js': 'export function parseArgs() {}\n',
+    },
+    check: (dir, finalText) => {
+      if (read(dir, 'b.js')?.includes('computeTax') !== true) return 'b.js damaged'
+      if (!/\bb\.js\b/.test(finalText)) return `answer missing "b.js": ${JSON.stringify(finalText)}`
+      return true
+    },
+  },
+]

--- a/eval/types.ts
+++ b/eval/types.ts
@@ -1,0 +1,31 @@
+/**
+ * A frozen task the agent must accomplish. Deliberately tiny and declarative:
+ * fixture files in, prompt in, a boolean (or failure-reason string) out.
+ *
+ * `check` runs AFTER the agent finishes, against the scenario's temp working
+ * directory. Return true to pass, or a string explaining the failure. Read the
+ * real files the agent touched — assert on outcomes, never on the agent's prose.
+ */
+export interface Scenario {
+  name: string
+  prompt: string
+  /** path (relative to temp cwd) -> initial file content. Dirs auto-created. */
+  files?: Record<string, string>
+  /**
+   * Outcome assertion. true = pass; string = fail reason.
+   * `finalText` is the agent's last plain-text answer — assert on it for
+   * locate/read tasks so a no-op run cannot false-pass.
+   */
+  check: (dir: string, finalText: string) => boolean | string | Promise<boolean | string>
+}
+
+export interface Result {
+  name: string
+  pass: boolean
+  reason?: string          // failure detail when !pass
+  toolCalls: number        // proxy for "how many turns / how much work"
+  promptTokens: number
+  evalTokens: number
+  durationMs: number
+  error?: string           // loop-level error (repetition kill, stream fail…)
+}

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
   },
   "scripts": {
     "start": "tsx src/cli.tsx",
+    "eval": "tsx src/cli.tsx eval",
+    "typecheck": "tsc --noEmit",
     "dev": "tsx watch src/cli.tsx",
     "build": "tsup",
     "postbuild": "node -e \"if(process.platform!=='win32')require('fs').chmodSync('dist/cli.js',0o755)\"",

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -3,4 +3,15 @@ import { render } from 'ink'
 import { createElement } from 'react'
 import { App } from './ui/App.js'
 
-render(createElement(App))
+const [, , cmd, ...rest] = process.argv
+
+if (cmd === 'doctor' || cmd === 'eval') {
+  // `miii doctor [models] [scenarioFilter]` — checks whether your installed
+  // models can actually drive the agent. Bundled into the shipped binary by
+  // tsup, so it works for global installs. `eval` is a hidden alias kept for
+  // CI / `npm run eval`. Lazy-imported so normal TUI startup stays lean.
+  const { runEval } = await import('../eval/run.js')
+  process.exit(await runEval(rest))
+} else {
+  render(createElement(App))
+}

--- a/src/prompt/system.ts
+++ b/src/prompt/system.ts
@@ -62,6 +62,7 @@ ${toolLines}
 - Stop emitting tool calls when GOAL is met. Reply with a concise plain-text final message confirming CRITERION is satisfied.
 
 # Rules
+- Always read a file before updating it. Never edit, overwrite, or create-over a file you have not read first this turn.
 - Prefer editing existing files over creating new ones.
 - For edit_file, ensure old_str is unique within the target file.
 - Never invent file paths. Read, glob, or grep before editing.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,9 +7,8 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "rootDir": "src",
     "outDir": "dist",
     "types": ["node"]
   },
-  "include": ["src"]
+  "include": ["src", "eval"]
 }


### PR DESCRIPTION
Add an outcome-checked eval harness in eval/ that drives the real agent loop and tools against fixed scenarios, scoring each model. Exposed two ways from one engine:
  - `miii doctor [models] [filter]` for users to check whether their local models can drive the agent (bundled into the shipped binary)
  - `npm run eval` as a CI/regression gate (non-zero exit on any failure)

Per-model verdict (ready / marginal / not recommended) and a compatibility matrix for multi-model runs. Cloud models skipped by default. README documents both doors and the stale-global-binary dev gotcha.