### PR TITLE
feat(cli): self-update command, auto-allow read-only tools, always em…

### DIFF
--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -5,7 +5,13 @@ import { App } from './ui/App.js'
 
 const [, , cmd, ...rest] = process.argv
 
-if (cmd === 'doctor' || cmd === 'eval') {
+if (cmd === 'update' || cmd === '--update' || cmd === '-u') {
+  // `miii --update` — self-update to the latest published version via npm.
+  const { spawnSync } = await import('child_process')
+  console.log('Updating miii-agent…')
+  const r = spawnSync('npm', ['i', '-g', 'miii-agent@latest'], { stdio: 'inherit', shell: process.platform === 'win32' })
+  process.exit(r.status ?? 1)
+} else if (cmd === 'doctor' || cmd === 'eval') {
   // `miii doctor [models] [scenarioFilter]` — checks whether your installed
   // models can actually drive the agent. Bundled into the shipped binary by
   // tsup, so it works for global installs. `eval` is a hidden alias kept for

--- a/src/permissions/policy.ts
+++ b/src/permissions/policy.ts
@@ -84,11 +84,16 @@ function matches(rule: Rule, toolName: string, subject: string): boolean {
   }
 }
 
+/** Read-only tools are always allowed — never prompt for these. */
+const ALWAYS_ALLOW = new Set(['read_file', 'grep', 'glob'])
+
 export async function check(
   toolName: string,
   input: unknown,
   ctx: PermissionContext,
 ): Promise<Decision> {
+  if (ALWAYS_ALLOW.has(toolName)) return 'allow'
+
   const subject = subjectFor(toolName, input)
   const rules = loadRules()
   if (rules.some((r) => matches(r, toolName, subject))) return 'allow'

--- a/src/tools/run_bash.ts
+++ b/src/tools/run_bash.ts
@@ -30,7 +30,7 @@ export const run_bash: Tool<Input> = {
       const out = [stdout, stderr].filter(Boolean).join('\n')
       const is_error = exitCode !== 0
       const body = out || (is_error ? `(no output)` : '')
-      const content = is_error ? `${body}\n[exit ${exitCode}]` : body
+      const content = `${body}\n[exit ${exitCode}]`
       return {
         content: content.slice(0, 32000),
         is_error,

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -111,7 +111,7 @@ export function App() {
 
       {updateAvailable && (
         <Box marginLeft={2} marginBottom={1}>
-          <Text color="yellow">{`↑ update available: v${updateAvailable} — run: npm i -g miii-agent`}</Text>
+          <Text color="yellow">{`↑ update available: v${updateAvailable} — run: miii --update`}</Text>
         </Box>
       )}
 


### PR DESCRIPTION
…it exit code

- `miii update`/`--update`/`-u` runs `npm i -g miii-agent@latest`; update banner points to it
- read-only tools (read_file/grep/glob) skip permission prompt
- run_bash always appends `[exit N]`