### PR TITLE
feat(tools): lossless output spill, ranged reads, smarter edit/glob

### DIFF
--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -2,6 +2,10 @@
 import { render } from 'ink'
 import { createElement } from 'react'
 import { App } from './ui/App.js'
+import { cleanupSpill } from './tools/spill.js'
+
+// Drop yesterday's spilled tool output before starting. Best-effort.
+cleanupSpill()
 
 const [, , cmd, ...rest] = process.argv
 

--- a/src/prompt/system.ts
+++ b/src/prompt/system.ts
@@ -64,9 +64,13 @@ ${toolLines}
 # Rules
 - Always read a file before updating it. Never edit, overwrite, or create-over a file you have not read first this turn.
 - Prefer editing existing files over creating new ones.
-- For edit_file, ensure old_str is unique within the target file.
+- For edit_file, make old_str unique by including surrounding context, or set replace_all to change every occurrence.
 - Never invent file paths. Read, glob, or grep before editing.
 - No filler, no pleasantries, no apologies.
+
+# Context discipline
+- read_file returns line numbers and accepts offset/limit. For large files, grep or glob to the relevant region first, then read only that range with offset/limit. Do not read a whole large file when you need a few functions — it wastes the context window.
+- Reference code by the line numbers read_file returns.
 
 # Testing and verification
 - Always test the code after a change. Run the project's tests (e.g. npm test, pytest, go test) or the relevant script via run_bash before declaring a task done.

--- a/src/tools/edit_file.ts
+++ b/src/tools/edit_file.ts
@@ -6,36 +6,87 @@ interface Input {
   path: string
   old_str: string
   new_str: string
+  replace_all?: boolean
+}
+
+/** Cheap line-similarity: fraction of matching chars by position, ignoring leading/trailing ws. */
+function similarity(a: string, b: string): number {
+  const x = a.trim()
+  const y = b.trim()
+  if (!x && !y) return 1
+  const len = Math.max(x.length, y.length)
+  if (len === 0) return 0
+  let same = 0
+  for (let i = 0; i < Math.min(x.length, y.length); i++) if (x[i] === y[i]) same++
+  return same / len
+}
+
+/**
+ * old_str didn't match. Find the source region most like it and show it back
+ * with line numbers, so the model can see the real whitespace/text instead of
+ * guessing again. This is the most expensive failure in an agent loop.
+ */
+function nearMiss(src: string, old_str: string): string {
+  const srcLines = src.split('\n')
+  const needle = old_str.split('\n').find((l) => l.trim()) ?? old_str
+  let bestIdx = -1
+  let bestScore = 0
+  for (let i = 0; i < srcLines.length; i++) {
+    const s = similarity(srcLines[i], needle)
+    if (s > bestScore) {
+      bestScore = s
+      bestIdx = i
+    }
+  }
+  if (bestIdx === -1 || bestScore < 0.4) return ''
+  const from = Math.max(0, bestIdx - 3)
+  const to = Math.min(srcLines.length, bestIdx + 4)
+  const width = String(to).length
+  const ctx = srcLines
+    .slice(from, to)
+    .map((l, i) => `${String(from + i + 1).padStart(width, ' ')}\t${l}`)
+    .join('\n')
+  return `\nClosest text in file (lines ${from + 1}-${to}):\n${ctx}`
 }
 
 export const edit_file: Tool<Input> = {
   name: 'edit_file',
-  description: 'Replace an exact string in a file. old_str must be unique.',
+  description:
+    'Replace an exact string in a file. old_str must be unique unless replace_all is set. On no match, returns the closest text in the file.',
   input_schema: {
     type: 'object',
     properties: {
-      path:    { type: 'string', description: 'File path' },
-      old_str: { type: 'string', description: 'Exact text to replace' },
-      new_str: { type: 'string', description: 'Replacement text' },
+      path:        { type: 'string', description: 'File path' },
+      old_str:     { type: 'string', description: 'Exact text to replace (whitespace-sensitive)' },
+      new_str:     { type: 'string', description: 'Replacement text' },
+      replace_all: { type: 'boolean', description: 'Replace every occurrence instead of requiring uniqueness' },
     },
     required: ['path', 'old_str', 'new_str'],
   },
-  handler: ({ path, old_str, new_str }) => {
+  handler: ({ path, old_str, new_str, replace_all }) => {
     try {
+      if (old_str === new_str) {
+        return { content: `old_str and new_str are identical — nothing to change in ${path}.`, is_error: true }
+      }
       const abs = confinePath(path)
       const src = readFileSync(abs, 'utf-8')
       const first = src.indexOf(old_str)
       if (first === -1) {
-        return { content: `old_str not found in ${path}`, is_error: true }
+        return { content: `old_str not found in ${path}.${nearMiss(src, old_str)}`, is_error: true }
       }
-      if (src.indexOf(old_str, first + 1) !== -1) {
-        return { content: `old_str not unique in ${path}`, is_error: true }
+      const all = replace_all === true
+      if (!all && src.indexOf(old_str, first + 1) !== -1) {
+        return {
+          content: `old_str not unique in ${path}. Add surrounding context to disambiguate, or set replace_all.`,
+          is_error: true,
+        }
       }
-      writeFileSync(abs, src.slice(0, first) + new_str + src.slice(first + old_str.length), 'utf-8')
-      return { content: `Edited ${path}` }
+      const out = all ? src.split(old_str).join(new_str) : src.slice(0, first) + new_str + src.slice(first + old_str.length)
+      const n = all ? src.split(old_str).length - 1 : 1
+      writeFileSync(abs, out, 'utf-8')
+      return { content: `Edited ${path}${all ? ` (${n} occurrences)` : ''}` }
     } catch (err) {
       return { content: err instanceof Error ? err.message : String(err), is_error: true }
     }
   },
 }
-

--- a/src/tools/glob.ts
+++ b/src/tools/glob.ts
@@ -1,5 +1,20 @@
 import { execa } from 'execa'
+import { statSync } from 'fs'
 import type { Tool } from './types.js'
+
+// Sort newest-first; "what did I just touch" is the common intent.
+// Files that vanish between listing and stat sink to the bottom.
+function byMtimeDesc(paths: string[]): string[] {
+  const mtime = new Map<string, number>()
+  for (const p of paths) {
+    try {
+      mtime.set(p, statSync(p).mtimeMs)
+    } catch {
+      mtime.set(p, 0)
+    }
+  }
+  return [...paths].sort((a, b) => (mtime.get(b) ?? 0) - (mtime.get(a) ?? 0))
+}
 
 interface Input {
   pattern: string
@@ -7,8 +22,16 @@ interface Input {
   max_results?: number
 }
 
-function globToFindName(glob: string): string {
-  return glob
+// Build `find` args approximating a glob, for machines without ripgrep.
+// No slash after stripping a leading globstar -> match basename with -name.
+// Slash remains (e.g. a "src" prefix) -> match full path with -path, globstar -> single star.
+function globToFindArgs(root: string, glob: string): string[] {
+  const stripped = glob.replace(/^\*\*\//, '')
+  if (!stripped.includes('/')) {
+    return [root, '-type', 'f', '-name', stripped]
+  }
+  const pathPat = '*/' + glob.replace(/\*\*/g, '*')
+  return [root, '-type', 'f', '-path', pathPat]
 }
 
 export const glob: Tool<Input> = {
@@ -33,13 +56,11 @@ export const glob: Tool<Input> = {
         timeout: 20000,
       })
 
-    const tryFind = () => {
-      const name = globToFindName(pattern.replace(/^\*\*\//, ''))
-      return execa('find', [root, '-type', 'f', '-name', name], {
+    const tryFind = () =>
+      execa('find', globToFindArgs(root, pattern), {
         reject: false,
         timeout: 20000,
       })
-    }
 
     try {
       let res
@@ -51,8 +72,9 @@ export const glob: Tool<Input> = {
       } catch {
         res = await tryFind()
       }
-      const lines = (res.stdout ?? '').split('\n').filter(Boolean).slice(0, limit)
-      if (lines.length === 0) return { content: 'No files matched.' }
+      const all = (res.stdout ?? '').split('\n').filter(Boolean)
+      if (all.length === 0) return { content: 'No files matched.' }
+      const lines = byMtimeDesc(all).slice(0, limit)
       return { content: lines.join('\n') }
     } catch (err) {
       return { content: err instanceof Error ? err.message : String(err), is_error: true }

--- a/src/tools/grep.ts
+++ b/src/tools/grep.ts
@@ -18,7 +18,7 @@ export const grep: Tool<Input> = {
       pattern:          { type: 'string', description: 'Regex pattern' },
       path:             { type: 'string', description: 'Root path to search (default cwd)' },
       glob:             { type: 'string', description: 'File glob filter, e.g. "*.ts"' },
-      case_insensitive: { type: 'string', description: 'Set "true" for case-insensitive' },
+      case_insensitive: { type: 'boolean', description: 'Case-insensitive match' },
       max_results:      { type: 'number', description: 'Max matching lines (default 200)' },
     },
     required: ['pattern'],

--- a/src/tools/paths.ts
+++ b/src/tools/paths.ts
@@ -1,4 +1,16 @@
-import { resolve, relative, isAbsolute, sep } from 'path'
+import { resolve, relative, isAbsolute, sep, join } from 'path'
+import { homedir } from 'os'
+
+/** App-owned spill directory (see spill.ts). Trusted so the model can page large
+ *  tool output written here, even though it sits outside cwd. confinePath also
+ *  backs write_file/edit_file, so this grants writes here too — acceptable: the
+ *  dir is app-owned and auto-cleaned on startup. */
+const SPILL_DIR = resolve(join(homedir(), '.miii', 'output'))
+
+function isUnder(parent: string, child: string): boolean {
+  const rel = relative(parent, child)
+  return rel === '' || (!rel.startsWith('..' + sep) && rel !== '..' && !isAbsolute(rel))
+}
 
 /**
  * Resolve a tool-supplied path against the current working directory and reject
@@ -14,9 +26,10 @@ export function confinePath(p: string): string {
   }
   const root = process.cwd()
   const abs = resolve(root, p)
-  const rel = relative(root, abs)
-  if (rel === '..' || rel.startsWith('..' + sep) || isAbsolute(rel)) {
-    throw new Error(`Path "${p}" is outside the working directory (${root}). Access denied.`)
+  // Allow reads/writes inside cwd, plus the app-owned spill dir (large tool
+  // output the model needs to page back in).
+  if (isUnder(root, abs) || isUnder(SPILL_DIR, abs)) {
+    return abs
   }
-  return abs
+  throw new Error(`Path "${p}" is outside the working directory (${root}). Access denied.`)
 }

--- a/src/tools/read_file.ts
+++ b/src/tools/read_file.ts
@@ -4,24 +4,57 @@ import type { Tool } from './types.js'
 
 interface Input {
   path: string
+  offset?: number
+  limit?: number
+}
+
+/** Left-pad a line number to width for stable, greppable columns. */
+function numbered(lines: string[], start: number): string {
+  const width = String(start + lines.length - 1).length
+  return lines
+    .map((l, i) => `${String(start + i).padStart(width, ' ')}\t${l}`)
+    .join('\n')
 }
 
 export const read_file: Tool<Input> = {
   name: 'read_file',
-  description: 'Read entire file contents as UTF-8 text.',
+  description:
+    'Read file contents as UTF-8 text with line numbers. Use offset/limit to read a range of a large file instead of the whole thing.',
   input_schema: {
     type: 'object',
     properties: {
-      path: { type: 'string', description: 'File path' },
+      path:   { type: 'string', description: 'File path' },
+      offset: { type: 'number', description: '1-based line to start from (default 1)' },
+      limit:  { type: 'number', description: 'Max lines to return (default all / capped)' },
     },
     required: ['path'],
   },
-  handler: ({ path }) => {
+  handler: ({ path, offset, limit }) => {
     try {
-      const MAX = 200_000
-      const raw = readFileSync(confinePath(path), 'utf-8')
-      const truncated = raw.length > MAX
-      const body = truncated ? raw.slice(0, MAX) + `\n[truncated: ${raw.length - MAX} more chars]` : raw
+      const MAX_CHARS = 200_000
+      const buf = readFileSync(confinePath(path))
+      // Refuse binary — NUL byte in the head is the cheap, reliable signal.
+      if (buf.subarray(0, 8000).includes(0)) {
+        return { content: `${path} looks binary (${buf.length} bytes); not reading as text.`, is_error: true }
+      }
+      // Normalize CRLF so the \r doesn't ride along on every numbered line.
+      const raw = buf.toString('utf-8').replace(/\r\n/g, '\n')
+      const allLines = raw.split('\n')
+      const total = allLines.length
+
+      const start = Math.max(1, Math.floor(offset ?? 1))
+      const ranged = offset != null || limit != null
+      const count = limit != null ? Math.max(0, Math.floor(limit)) : total
+      const slice = allLines.slice(start - 1, start - 1 + count)
+
+      let body = numbered(slice, start)
+      if (body.length > MAX_CHARS) {
+        body = body.slice(0, MAX_CHARS) + `\n[truncated: output exceeded ${MAX_CHARS} chars — use offset/limit]`
+      }
+      if (ranged) {
+        const end = start - 1 + slice.length
+        body += `\n[showing lines ${start}-${end} of ${total}]`
+      }
       return { content: body }
     } catch (err) {
       return { content: err instanceof Error ? err.message : String(err), is_error: true }

--- a/src/tools/run_bash.ts
+++ b/src/tools/run_bash.ts
@@ -1,4 +1,5 @@
 import { execa } from 'execa'
+import { spillIfLarge } from './spill.js'
 import type { Tool } from './types.js'
 
 interface Input {
@@ -30,9 +31,9 @@ export const run_bash: Tool<Input> = {
       const out = [stdout, stderr].filter(Boolean).join('\n')
       const is_error = exitCode !== 0
       const body = out || (is_error ? `(no output)` : '')
-      const content = `${body}\n[exit ${exitCode}]`
+      const content = `${spillIfLarge(body, 'command output')}\n[exit ${exitCode}]`
       return {
-        content: content.slice(0, 32000),
+        content,
         is_error,
       }
     } catch (err) {

--- a/src/tools/spill.ts
+++ b/src/tools/spill.ts
@@ -1,0 +1,70 @@
+import { writeFileSync, mkdirSync, rmSync, readdirSync, statSync } from 'fs'
+import { join } from 'path'
+import { homedir } from 'os'
+import { randomBytes } from 'crypto'
+
+/**
+ * Overflow handling for tool output. Instead of truncating (lossy) we spill the
+ * FULL output to a file and inline only a head+tail preview. The model pages the
+ * rest through read_file with offset/limit, so nothing is ever lost and the
+ * inline budget is just "how much to show", not "how much exists".
+ */
+
+const OUTPUT_DIR = join(homedir(), '.miii', 'output')
+
+/** Bytes inlined before spilling. ~2.5K tokens — enough to read most results whole. */
+export const INLINE_BUDGET = 10_000
+
+/** Keep this fraction of the budget as head; the rest is tail (errors live at the bottom). */
+const HEAD_FRACTION = 0.3
+
+function ensureDir(): string {
+  mkdirSync(OUTPUT_DIR, { recursive: true })
+  return OUTPUT_DIR
+}
+
+/**
+ * If `full` fits the budget, return it unchanged. Otherwise write it to a file
+ * and return a head+tail preview plus a pointer telling the model how to read
+ * the rest. `label` names the source (e.g. "command output") for the notice.
+ */
+export function spillIfLarge(full: string, label = 'output', budget = INLINE_BUDGET): string {
+  if (full.length <= budget) return full
+
+  const id = randomBytes(6).toString('hex')
+  const file = join(ensureDir(), `${id}.txt`)
+  let path = file
+  try {
+    writeFileSync(file, full, 'utf-8')
+  } catch {
+    // Spill failed (e.g. read-only home) — fall back to lossy head+tail so we
+    // never blow the context window, but say the tail was dropped.
+    path = ''
+  }
+
+  const head = Math.floor(budget * HEAD_FRACTION)
+  const tail = budget - head
+  const totalLines = full.split('\n').length
+  const preview = full.slice(0, head) + '\n…\n' + full.slice(-tail)
+  const notice = path
+    ? `[${label} truncated: ${totalLines} lines / ${full.length} bytes. Full output at ${path} — read it with read_file offset/limit to see the elided middle.]`
+    : `[${label} truncated to ${budget} bytes; spill to disk failed, middle is lost.]`
+  return `${preview}\n${notice}`
+}
+
+/** Delete spilled output files older than `maxAgeMs` (default 24h). Best-effort. */
+export function cleanupSpill(maxAgeMs = 24 * 60 * 60 * 1000): void {
+  try {
+    const now = Date.now()
+    for (const name of readdirSync(OUTPUT_DIR)) {
+      const f = join(OUTPUT_DIR, name)
+      try {
+        if (now - statSync(f).mtimeMs > maxAgeMs) rmSync(f, { force: true })
+      } catch {
+        /* ignore individual file errors */
+      }
+    }
+  } catch {
+    /* dir missing — nothing to clean */
+  }
+}


### PR DESCRIPTION
Tool ergonomics so the model wastes fewer turns and less context.

- run_bash: replace lossy 32K truncation with spill-to-file. Full output written to ~/.miii/output, head+tail preview + read pointer inlined; model pages the rest via read_file offset/limit. Nothing lost; resolves the 32K-vs-200K cap inconsistency at the mechanism level.
- read_file: line numbers + offset/limit ranged reads, binary refusal (NUL), CRLF normalize. Lets the model read regions of large files instead of dumping.
- edit_file: near-miss context on no-match, replace_all flag, no-op guard.
- glob: real find fallback (was a no-op stub), mtime sort newest-first.
- grep: fix case_insensitive schema type (string -> boolean).
- paths: allow confined access to the app-owned spill dir.
- system prompt: steer toward ranged reads and replace_all.