### PR TITLE
feat(ui/tools): ctrl+o expand, diff bg highlight, fuzzy edit, verify nudge

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Once inside the TUI, just type naturally:
 | `/models` | Switch active Ollama model |
 | `/clear` | Reset conversation history |
 | `Esc` | Stop current generation or tool run |
+| `Ctrl+O` | Toggle full tool output view |
 | `Ctrl+C` | Quit |
 
 ---
@@ -124,12 +125,30 @@ miii ships with a built-in tool suite the agent can invoke autonomously:
 |------|-------------|
 | `read_file` | Read any file in your workspace |
 | `write_file` | Create new files |
-| `edit_file` | Precise string-level edits (no rewrites) |
+| `edit_file` | Precise string-level edits with whitespace tolerance (no rewrites) |
 | `glob` | Pattern-match files across the project |
 | `grep` | Regex search across files |
 | `run_bash` | Execute shell commands |
 
 Every sensitive operation is gated by a permission system — you approve what the agent can touch, and "always" approvals persist to `~/.miii/permissions.json` so you're never asked twice. File tools are confined to your working directory; `../` traversal and absolute paths outside it are rejected.
+
+---
+
+## Lossless output spill
+
+Big tool outputs used to get truncated — a 50K-line test log chopped to 32K, the middle gone, the model guessing at what it missed. miii doesn't truncate. It **spills**.
+
+When a tool result exceeds the inline budget (~10K bytes), the full output is written to `~/.miii/output/<id>.txt`. Only a head + tail **preview** is inlined into the conversation, followed by a pointer:
+
+```
+[command output truncated: 5184 lines / 412900 bytes.
+ Full output at ~/.miii/output/9f3a1c.txt — read it with
+ read_file offset/limit to see the elided middle.]
+```
+
+The head shows where output started; the tail catches the errors and summaries that live at the bottom. If the model needs the elided middle, it pages through it with `read_file` ranged reads — nothing is ever lost. The inline budget becomes "how much to show," not "how much exists."
+
+Spill files are confined to the app-owned `~/.miii/output` dir and garbage-collected after 24h. If the spill write fails (e.g. read-only home), miii falls back to a lossy head+tail and says so explicitly, so the context window is never blown.
 
 ---
 
@@ -195,6 +214,10 @@ graph TD
         ReadFile -.-> Confine["Path Confinement\n(tools/paths.ts)"]
         WriteFile -.-> Confine
         EditFile -.-> Confine
+        RunBash -->|"large output"| SpillMod["Output Spill\n(tools/spill.ts)"]
+        Grep -->|"large output"| SpillMod
+        Glob -->|"large output"| SpillMod
+        SpillMod -.->|"head+tail preview\n+ read pointer"| ToolRegistry
     end
 
     Adapter -->|"HTTP streaming"| Ollama["Ollama\n(local LLM server)"]
@@ -206,10 +229,13 @@ graph TD
     subgraph Storage ["Local Storage"]
         Config["~/.miii/config.json\n(model, host, effort)"]
         Rules["~/.miii/permissions.json\n(saved allow rules)"]
+        Spill["~/.miii/output/\n(spilled tool output)"]
     end
 
     App -.->|"reads"| Config
     Policy -.->|"reads / persists 'always'"| Rules
+    SpillMod -.->|"writes full output"| Spill
+    ReadFile -.->|"pages elided middle\n(offset/limit)"| Spill
 ```
 
 ---

--- a/src/tools/edit_file.ts
+++ b/src/tools/edit_file.ts
@@ -1,5 +1,6 @@
 import { readFileSync, writeFileSync } from 'fs'
 import { confinePath } from './paths.js'
+import { verifyHint } from './verifyHint.js'
 import type { Tool } from './types.js'
 
 interface Input {
@@ -19,6 +20,46 @@ function similarity(a: string, b: string): number {
   let same = 0
   for (let i = 0; i < Math.min(x.length, y.length); i++) if (x[i] === y[i]) same++
   return same / len
+}
+
+/**
+ * Exact match failed. Try matching old_str against src ignoring per-line
+ * leading/trailing whitespace — the most common reason a model's old_str misses.
+ * Returns the [start, end] char range in src of a unique whitespace-tolerant
+ * match, or null if there is no match or more than one.
+ */
+function fuzzyRange(src: string, old_str: string): [number, number] | null {
+  const srcLines = src.split('\n')
+  const oldLines = old_str.split('\n')
+  const norm = (l: string) => l.trim()
+  const oldNorm = oldLines.map(norm)
+
+  // Char offset of the start of each src line.
+  const offsets: number[] = new Array(srcLines.length)
+  let acc = 0
+  for (let i = 0; i < srcLines.length; i++) {
+    offsets[i] = acc
+    acc += srcLines[i].length + 1 // +1 for the '\n'
+  }
+
+  const matches: Array<[number, number]> = []
+  const window = oldLines.length
+  for (let i = 0; i + window <= srcLines.length; i++) {
+    let ok = true
+    for (let j = 0; j < window; j++) {
+      if (norm(srcLines[i + j]) !== oldNorm[j]) {
+        ok = false
+        break
+      }
+    }
+    if (!ok) continue
+    const start = offsets[i]
+    const last = i + window - 1
+    const end = offsets[last] + srcLines[last].length
+    matches.push([start, end])
+  }
+
+  return matches.length === 1 ? matches[0] : null
 }
 
 /**
@@ -72,6 +113,16 @@ export const edit_file: Tool<Input> = {
       const src = readFileSync(abs, 'utf-8')
       const first = src.indexOf(old_str)
       if (first === -1) {
+        // Exact match failed — try a unique whitespace-tolerant match before giving up.
+        if (replace_all !== true) {
+          const fuzzy = fuzzyRange(src, old_str)
+          if (fuzzy) {
+            const [s, e] = fuzzy
+            const out = src.slice(0, s) + new_str + src.slice(e)
+            writeFileSync(abs, out, 'utf-8')
+            return { content: `Edited ${path} (whitespace-tolerant match).${verifyHint(path)}` }
+          }
+        }
         return { content: `old_str not found in ${path}.${nearMiss(src, old_str)}`, is_error: true }
       }
       const all = replace_all === true
@@ -84,7 +135,7 @@ export const edit_file: Tool<Input> = {
       const out = all ? src.split(old_str).join(new_str) : src.slice(0, first) + new_str + src.slice(first + old_str.length)
       const n = all ? src.split(old_str).length - 1 : 1
       writeFileSync(abs, out, 'utf-8')
-      return { content: `Edited ${path}${all ? ` (${n} occurrences)` : ''}` }
+      return { content: `Edited ${path}${all ? ` (${n} occurrences)` : ''}.${verifyHint(path)}` }
     } catch (err) {
       return { content: err instanceof Error ? err.message : String(err), is_error: true }
     }

--- a/src/tools/verifyHint.ts
+++ b/src/tools/verifyHint.ts
@@ -1,0 +1,32 @@
+/**
+ * After a successful write/edit, suggest a language-appropriate command to
+ * compile or syntax-check the file. The agent loop tends to skip the "now test
+ * it" step; returning a concrete command in the tool result nudges it to run
+ * run_bash and catch errors it introduced, then re-fix.
+ */
+export function verifyHint(path: string): string {
+  const ext = path.slice(path.lastIndexOf('.') + 1).toLowerCase()
+  const cmds: Record<string, string> = {
+    ts:   `npx tsc --noEmit`,
+    tsx:  `npx tsc --noEmit`,
+    js:   `node --check ${path}`,
+    jsx:  `node --check ${path}`,
+    mjs:  `node --check ${path}`,
+    cjs:  `node --check ${path}`,
+    py:   `python -m py_compile ${path}`,
+    go:   `go build ./...`,
+    rs:   `cargo check`,
+    rb:   `ruby -c ${path}`,
+    php:  `php -l ${path}`,
+    sh:   `bash -n ${path}`,
+    bash: `bash -n ${path}`,
+    c:    `gcc -fsyntax-only ${path}`,
+    h:    `gcc -fsyntax-only ${path}`,
+    cpp:  `g++ -fsyntax-only ${path}`,
+    cc:   `g++ -fsyntax-only ${path}`,
+    java: `javac -d /tmp ${path}`,
+  }
+  const cmd = cmds[ext]
+  if (!cmd) return ''
+  return ` Now verify via run_bash: ${cmd} — fix any errors it reports before continuing.`
+}

--- a/src/tools/write_file.ts
+++ b/src/tools/write_file.ts
@@ -1,6 +1,7 @@
 import { writeFileSync, mkdirSync } from 'fs'
 import { dirname } from 'path'
 import { confinePath } from './paths.js'
+import { verifyHint } from './verifyHint.js'
 import type { Tool } from './types.js'
 
 interface Input {
@@ -24,7 +25,7 @@ export const write_file: Tool<Input> = {
       const abs = confinePath(path)
       mkdirSync(dirname(abs), { recursive: true })
       writeFileSync(abs, content, 'utf-8')
-      return { content: `Wrote ${path} (${content.length} bytes)` }
+      return { content: `Wrote ${path} (${content.length} bytes).${verifyHint(path)}` }
     } catch (err) {
       return { content: err instanceof Error ? err.message : String(err), is_error: true }
     }

--- a/src/ui/ChatView.tsx
+++ b/src/ui/ChatView.tsx
@@ -1,7 +1,29 @@
+import { useState, useEffect } from 'react'
 import { Box, Text } from 'ink'
 import { ThinkingBlock } from './ThinkingBlock.js'
 import type { ChatMessage, ToolUseDisplay, ToolResultDisplay, PermissionRequest } from './types.js'
 import { EMPTY_STATE_HINTS, EMPTY_STATE_TITLE, } from './constants.js'
+
+// Tool output is collapsed to a few lines by default; ctrl+o toggles full view.
+const COLLAPSED_LINES = 3
+
+let globalToolExpanded = false
+const toolExpandListeners = new Set<() => void>()
+
+export function toggleToolExpanded() {
+  globalToolExpanded = !globalToolExpanded
+  toolExpandListeners.forEach((fn) => fn())
+}
+
+function useToolExpanded() {
+  const [expanded, setExpanded] = useState(globalToolExpanded)
+  useEffect(() => {
+    const handler = () => setExpanded(globalToolExpanded)
+    toolExpandListeners.add(handler)
+    return () => { toolExpandListeners.delete(handler) }
+  }, [])
+  return expanded
+}
 
 interface Props {
   messages: ChatMessage[]
@@ -47,8 +69,8 @@ function FileEditBlock({
   removed: number
   previewLines: Array<{ sign: '+' | '-' | ' '; text: string }>
 }) {
-  const MAX = 16
-  const shown = previewLines.slice(0, MAX)
+  const expanded = useToolExpanded()
+  const shown = expanded ? previewLines : previewLines.slice(0, COLLAPSED_LINES)
   const extra = previewLines.length - shown.length
   return (
     <Box flexDirection="column" marginLeft={2}>
@@ -65,16 +87,23 @@ function FileEditBlock({
           {removed > 0 ? `Added ${added} lines, removed ${removed} lines` : `Added ${added} lines`}
         </Text>
       </Box>
-      {shown.map((ln, i) => (
-        <Box key={i} marginLeft={4}>
-          <Text color={ln.sign === '+' ? 'green' : ln.sign === '-' ? 'red' : undefined} dimColor={ln.sign === ' '}>
-            {ln.sign} {ln.text}
-          </Text>
-        </Box>
-      ))}
+      {shown.map((ln, i) => {
+        const width = (process.stdout.columns ?? 80) - 6
+        const content = `${ln.sign} ${ln.text}`.padEnd(width)
+        return (
+          <Box key={i} marginLeft={4}>
+            <Text
+              backgroundColor={ln.sign === '+' ? '#13351f' : ln.sign === '-' ? '#3b1414' : undefined}
+              dimColor={ln.sign === ' '}
+            >
+              {content}
+            </Text>
+          </Box>
+        )
+      })}
       {extra > 0 && (
         <Box marginLeft={4}>
-          <Text dimColor>… {extra} more lines</Text>
+          <Text dimColor>… {extra} more lines · ctrl+o to expand</Text>
         </Box>
       )}
     </Box>
@@ -147,6 +176,7 @@ function summarizeResult(res: ToolResultDisplay, toolName?: string): string {
 }
 
 function ToolResultBlock({ result, toolName }: { result: ToolResultDisplay; toolName: string }) {
+  const expanded = useToolExpanded()
   const content = result.content ?? ''
   const lines = content.split('\n')
   const showMulti =
@@ -161,9 +191,9 @@ function ToolResultBlock({ result, toolName }: { result: ToolResultDisplay; tool
       </Box>
     )
   }
-  const MAX_LINES = 10
   const MAX_LINE_WIDTH = 200
-  const shown = lines.slice(0, MAX_LINES).map((l) => truncate(l, MAX_LINE_WIDTH))
+  const visible = expanded ? lines : lines.slice(0, COLLAPSED_LINES)
+  const shown = visible.map((l) => truncate(l, MAX_LINE_WIDTH))
   const extra = lines.length - shown.length
   return (
     <Box flexDirection="column" marginLeft={2}>
@@ -177,7 +207,7 @@ function ToolResultBlock({ result, toolName }: { result: ToolResultDisplay; tool
       ))}
       {extra > 0 && (
         <Box marginLeft={4}>
-          <Text dimColor>… {extra} more lines</Text>
+          <Text dimColor>… {extra} more lines · ctrl+o to expand</Text>
         </Box>
       )}
     </Box>

--- a/src/ui/hooks/useKeyboard.ts
+++ b/src/ui/hooks/useKeyboard.ts
@@ -9,6 +9,7 @@ import { setModel, setEffort, type Effort } from '../../config.js'
 import { filteredCommands } from '../CommandPalette.js'
 import { parseMention, searchFiles } from '../FilePicker.js'
 import { toggleThinkingVisible } from '../ThinkingBlock.js'
+import { toggleToolExpanded } from '../ChatView.js'
 import {
   summarizeMessage,
   persistSession,
@@ -91,6 +92,8 @@ export function useKeyboard(opts: KeyboardOptions) {
     if (key.ctrl && char === 'c') { exit(); return }
     // Ctrl+T toggles thinking block content visibility
     if (key.ctrl && char === 't') { toggleThinkingVisible(); return }
+    // Ctrl+O toggles full tool output (collapsed to a few lines by default)
+    if (key.ctrl && char === 'o') { toggleToolExpanded(); return }
 
     if (key.escape && busyRef.current && abortRef.current) {
       abortRef.current.abort()


### PR DESCRIPTION

- ChatView: collapse tool output/diffs to 3 lines, ctrl+o toggles full view via a shared store; diff lines now full-width background highlight (no fg color)
- useKeyboard: wire ctrl+o to toggleToolExpanded
- edit_file: whitespace-tolerant unique match fallback when exact old_str misses
- write_file/edit_file: append verifyHint — language-aware compile/syntax-check command to nudge the agent to self-verify
- README: document lossless output spill + architecture diagram update