### PR TITLE
feat(prompt): read project MIII.md into system prompt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .DS_Store
 .claude
 .miii
+.vitest-*

--- a/README.md
+++ b/README.md
@@ -120,6 +120,19 @@ Inside the TUI, interact naturally:
 | `Ctrl+O` | Toggle full tool output view |
 | `Ctrl+C` | Quit |
 
+### Project Instructions (`MIII.md`)
+
+Drop a `MIII.md` file in your project and miii reads it first, every turn — the same idea as `CLAUDE.md`. Use it to teach the agent your conventions, build/test commands, architecture, and do's and don'ts.
+
+```markdown
+# MIII.md
+- Use tabs, not spaces.
+- Run `npm test` before declaring any task done.
+- The HTTP layer lives in src/server/ — never import it from src/core/.
+```
+
+miii searches upward from the working directory to the repo root (the directory containing `.git`); the nearest `MIII.md` wins. It is treated as authoritative — higher priority than the agent's defaults — except it can never override the permission system or safety boundaries. Files over 32KB are truncated.
+
 ---
 
 ## Technical Deep Dive
@@ -137,7 +150,7 @@ miii ships with a built-in tool suite that the agent invokes autonomously:
 | `grep` | Regex search across files |
 | `run_bash` | Execute shell commands |
 
-**Security & Safety:** Every sensitive operation is gated by a permission system. You approve what the agent can touch, and "always" approvals persist to `~/.miii/permissions.json`. File tools are strictly confined to your working directory; `../` traversal and absolute paths outside the workspace are rejected.
+**Security & Safety:** Every sensitive operation is gated by a permission system. You approve what the agent can touch, and "always" approvals persist to `~/.miii/permissions.json`. The file tools (`read_file`, `write_file`, `edit_file`) are strictly confined to your working directory; `../` traversal and absolute paths outside the workspace are rejected. `run_bash` runs arbitrary shell commands and is **not** path-confined — its only boundary is the permission prompt, so review commands before approving (especially "always").
 
 ### Lossless Output Spill
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,8 @@
         "@types/react": "^18.3.0",
         "tsup": "^8.5.1",
         "tsx": "^4.19.0",
-        "typescript": "^5.7.0"
+        "typescript": "^5.7.0",
+        "vitest": "^4.1.9"
       },
       "engines": {
         "node": ">=18"
@@ -42,6 +43,40 @@
       },
       "engines": {
         "node": ">=14.13.1"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -525,6 +560,317 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
+      "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.61.1",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.61.1.tgz",
@@ -893,10 +1239,46 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@types/cardinal": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@types/cardinal/-/cardinal-2.1.1.tgz",
       "integrity": "sha512-/xCVwg8lWvahHsV2wXZt4i64H1sdL+sN1Uoq7fAc8/FA6uYHjuIveDwPwvGUYp4VZiv85dVl6J/Bum3NDAOm8g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
       "dev": true,
       "license": "MIT"
     },
@@ -961,6 +1343,119 @@
         "csstype": "^3.2.2"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.9",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -1019,6 +1514,16 @@
       "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
       "license": "MIT"
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/auto-bind": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-5.0.1.tgz",
@@ -1055,6 +1560,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -1346,6 +1861,13 @@
         "node": "^14.18.0 || >=16.10.0"
       }
     },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/convert-to-spaces": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/convert-to-spaces/-/convert-to-spaces-2.0.1.tgz",
@@ -1394,6 +1916,16 @@
         }
       }
     },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/emoji-regex": {
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
@@ -1411,6 +1943,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-toolkit": {
       "version": "1.47.0",
@@ -1482,6 +2021,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/execa": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
@@ -1506,6 +2055,16 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fdir": {
@@ -1783,6 +2342,279 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
     },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/lilconfig": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
@@ -1875,6 +2707,25 @@
         "thenify-all": "^1.0.0"
       }
     },
+    "node_modules/nanoid": {
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/npm-run-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
@@ -1910,6 +2761,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/ollama": {
@@ -2034,6 +2899,35 @@
         "confbox": "^0.1.8",
         "mlly": "^1.7.4",
         "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/postcss-load-config": {
@@ -2177,6 +3071,40 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC"
     },
+    "node_modules/rolldown": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.133.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.3",
+        "@rolldown/binding-darwin-arm64": "1.0.3",
+        "@rolldown/binding-darwin-x64": "1.0.3",
+        "@rolldown/binding-freebsd-x64": "1.0.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
+        "@rolldown/binding-linux-arm64-musl": "1.0.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-musl": "1.0.3",
+        "@rolldown/binding-openharmony-arm64": "1.0.3",
+        "@rolldown/binding-wasm32-wasi": "1.0.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
+        "@rolldown/binding-win32-x64-msvc": "1.0.3"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.61.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.61.1.tgz",
@@ -2252,6 +3180,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -2305,6 +3240,16 @@
         "node": ">= 12"
       }
     },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/stack-utils": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
@@ -2316,6 +3261,20 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "7.2.0",
@@ -2417,6 +3376,13 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
@@ -2441,6 +3407,16 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/tree-kill": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
@@ -2457,6 +3433,14 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/tsup": {
       "version": "8.5.1",
@@ -3066,6 +4050,184 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/vite": {
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.3",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.9",
+        "@vitest/mocker": "4.1.9",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/runner": "4.1.9",
+        "@vitest/snapshot": "4.1.9",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.9",
+        "@vitest/browser-preview": "4.1.9",
+        "@vitest/browser-webdriverio": "4.1.9",
+        "@vitest/coverage-istanbul": "4.1.9",
+        "@vitest/coverage-v8": "4.1.9",
+        "@vitest/ui": "4.1.9",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/whatwg-fetch": {
       "version": "3.6.20",
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
@@ -3085,6 +4247,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/widest-line": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "start": "tsx src/cli.tsx",
     "eval": "tsx src/cli.tsx eval",
     "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "dev": "tsx watch src/cli.tsx",
     "build": "tsup",
     "postbuild": "node -e \"if(process.platform!=='win32')require('fs').chmodSync('dist/cli.js',0o755)\"",
@@ -49,6 +51,7 @@
     "@types/react": "^18.3.0",
     "tsup": "^8.5.1",
     "tsx": "^4.19.0",
-    "typescript": "^5.7.0"
+    "typescript": "^5.7.0",
+    "vitest": "^4.1.9"
   }
 }

--- a/src/agent/adapter.test.ts
+++ b/src/agent/adapter.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest'
+import { parseTextToolCalls, blocksFromOllama, toOllamaMessages } from './adapter.js'
+import type { MiiMessage, ToolUse } from './types.js'
+
+const KNOWN = ['read_file', 'edit_file', 'run_bash']
+
+describe('parseTextToolCalls', () => {
+  it('parses a <tool_call>-wrapped JSON object', () => {
+    const { calls, cleanedText } = parseTextToolCalls(
+      'sure\n<tool_call>{"name":"read_file","arguments":{"path":"a.ts"}}</tool_call>',
+      KNOWN,
+    )
+    expect(calls).toHaveLength(1)
+    expect(calls[0].function).toEqual({ name: 'read_file', arguments: { path: 'a.ts' } })
+    expect(cleanedText).toBe('sure')
+  })
+
+  it('parses a fenced json block and strips it', () => {
+    const { calls, cleanedText } = parseTextToolCalls(
+      '```json\n{"name":"run_bash","arguments":{"command":"ls"}}\n```',
+      KNOWN,
+    )
+    expect(calls).toHaveLength(1)
+    expect(calls[0].function.name).toBe('run_bash')
+    expect(cleanedText).toBe('')
+  })
+
+  it('accepts the "parameters" alias for arguments', () => {
+    const { calls } = parseTextToolCalls('{"name":"read_file","parameters":{"path":"x"}}', KNOWN)
+    expect(calls[0].function.arguments).toEqual({ path: 'x' })
+  })
+
+  it('rejects an object whose name is not a known tool', () => {
+    const { calls, cleanedText } = parseTextToolCalls('{"name":"frobnicate","arguments":{}}', KNOWN)
+    expect(calls).toHaveLength(0)
+    // unknown object left in place, not silently eaten
+    expect(cleanedText).toContain('frobnicate')
+  })
+
+  it('does not treat prose mentioning a tool as a call', () => {
+    const { calls } = parseTextToolCalls('I will use read_file on the config.', KNOWN)
+    expect(calls).toHaveLength(0)
+  })
+
+  it('returns nothing for empty input', () => {
+    expect(parseTextToolCalls('', KNOWN).calls).toHaveLength(0)
+  })
+})
+
+describe('blocksFromOllama', () => {
+  it('prefers native structured tool_calls over text parsing', () => {
+    const blocks = blocksFromOllama(
+      'ignored body',
+      [{ function: { name: 'read_file', arguments: { path: 'a' } } }],
+      KNOWN,
+    )
+    const uses = blocks.filter((b) => b.type === 'tool_use') as ToolUse[]
+    expect(uses).toHaveLength(1)
+    expect(uses[0].name).toBe('read_file')
+    expect(uses[0].id).toMatch(/^toolu_/)
+  })
+
+  it('falls back to text-extracted calls when no native calls', () => {
+    const blocks = blocksFromOllama(
+      'doing it\n<tool_call>{"name":"run_bash","arguments":{"command":"ls"}}</tool_call>',
+      undefined,
+      KNOWN,
+    )
+    const texts = blocks.filter((b) => b.type === 'text')
+    const uses = blocks.filter((b) => b.type === 'tool_use') as ToolUse[]
+    expect((texts[0] as { text: string }).text).toBe('doing it')
+    expect(uses[0].name).toBe('run_bash')
+  })
+
+  it('emits a lone text block when there are no calls', () => {
+    const blocks = blocksFromOllama('just an answer', undefined, KNOWN)
+    expect(blocks).toEqual([{ type: 'text', text: 'just an answer' }])
+  })
+})
+
+describe('toOllamaMessages', () => {
+  it('prepends the system message', () => {
+    const out = toOllamaMessages([], 'SYS')
+    expect(out[0]).toEqual({ role: 'system', content: 'SYS' })
+  })
+
+  it('maps assistant tool_use blocks to tool_calls', () => {
+    const history: MiiMessage[] = [
+      {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: 'hi' },
+          { type: 'tool_use', id: 'toolu_1', name: 'read_file', input: { path: 'a' } },
+        ],
+      },
+    ]
+    const out = toOllamaMessages(history, 'SYS')
+    const asst = out[1]
+    expect(asst.role).toBe('assistant')
+    expect(asst.content).toBe('hi')
+    expect(asst.tool_calls).toEqual([
+      { id: 'toolu_1', function: { name: 'read_file', arguments: { path: 'a' } } },
+    ])
+  })
+
+  it('emits one role:tool message per tool_result, in order, after the assistant', () => {
+    const history: MiiMessage[] = [
+      {
+        role: 'assistant',
+        content: [
+          { type: 'tool_use', id: 'toolu_1', name: 'read_file', input: {} },
+          { type: 'tool_use', id: 'toolu_2', name: 'run_bash', input: {} },
+        ],
+      },
+      {
+        role: 'user',
+        content: [
+          { type: 'tool_result', tool_use_id: 'toolu_1', content: 'A' },
+          { type: 'tool_result', tool_use_id: 'toolu_2', content: 'B' },
+        ],
+      },
+    ]
+    const out = toOllamaMessages(history, 'SYS')
+    // [system, assistant, tool(A), tool(B)]
+    expect(out.map((m) => m.role)).toEqual(['system', 'assistant', 'tool', 'tool'])
+    expect(out[2]).toMatchObject({ content: 'A', tool_call_id: 'toolu_1' })
+    expect(out[3]).toMatchObject({ content: 'B', tool_call_id: 'toolu_2' })
+  })
+})

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -1,8 +1,12 @@
+import { existsSync } from 'fs'
 import { chat } from '../llm/client.js'
+import { confinePath } from '../tools/paths.js'
 import { TOOLS, getTool, toOllamaTools } from '../tools/registry.js'
 import { validateInput } from '../tools/validate.js'
 import { buildSystemPrompt } from '../prompt/system.js'
+import { loadProjectContext } from '../prompt/context.js'
 import { check, type PermissionContext } from '../permissions/policy.js'
+import { loadConfig, EFFORT_OPTIONS } from '../config.js'
 import { HookBus } from '../hooks/bus.js'
 import { toOllamaMessages, blocksFromOllama } from './adapter.js'
 import type {
@@ -14,9 +18,40 @@ import type {
 } from './types.js'
 
 const MAX_TURNS = 25
-const NUM_PREDICT = 8192
 const REPEAT_TAIL = 120
 const REPEAT_KILL = 4
+
+/**
+ * Harness-enforced read-before-write. The system prompt asks the model to read
+ * a file before editing it, but weak local models ignore prose invariants — so
+ * we enforce it mechanically. `seen` holds canonical paths the model has read
+ * (or already written) this run. Returns an actionable error string to block
+ * the call, or null to allow it.
+ *
+ * - edit_file always targets an existing file → requires a prior read.
+ * - write_file creating a NEW file is allowed (nothing to read); overwriting an
+ *   existing file requires a prior read.
+ * Path/confinement problems are left to the tool handler to report.
+ */
+function readGuard(name: string, input: unknown, seen: Set<string>): string | null {
+  if (name !== 'edit_file' && name !== 'write_file') return null
+  const p = (input as { path?: unknown }).path
+  if (typeof p !== 'string' || !p) return null
+  let abs: string
+  try { abs = confinePath(p) } catch { return null }
+  if (seen.has(abs)) return null
+  if (name === 'write_file' && !existsSync(abs)) return null
+  const verb = name === 'edit_file' ? 'edit' : 'overwrite'
+  return `Refusing to ${verb} ${p}: you have not read it this turn. Call read_file on ${p} first, then retry the ${name}.`
+}
+
+/** Record a path the model now knows the current state of (read or wrote). */
+function markSeen(name: string, input: unknown, seen: Set<string>): void {
+  if (name !== 'read_file' && name !== 'edit_file' && name !== 'write_file') return
+  const p = (input as { path?: unknown }).path
+  if (typeof p !== 'string' || !p) return
+  try { seen.add(confinePath(p)) } catch { /* confinement error surfaced by tool */ }
+}
 
 export interface RunAgentOpts {
   model: string
@@ -43,8 +78,11 @@ export interface RunAgentOpts {
 export async function* runAgent(opts: RunAgentOpts): AsyncGenerator<AgentEvent, MiiMessage[]> {
   const { model, cwd, permissions, hooks, signal, num_ctx } = opts
   const startTime = Date.now()
-  const system = buildSystemPrompt(TOOLS, cwd)
+  const system = buildSystemPrompt(TOOLS, cwd, loadProjectContext(cwd))
   const ollamaTools = toOllamaTools(TOOLS)
+  // Effort drives temperature + output cap. high → num_predict -1 (unlimited),
+  // which ollama.chat omits so the model runs to its own stop.
+  const effort = EFFORT_OPTIONS[loadConfig().effort ?? 'medium']
 
   const history: MiiMessage[] = [
     ...opts.history,
@@ -55,6 +93,8 @@ export async function* runAgent(opts: RunAgentOpts): AsyncGenerator<AgentEvent, 
   let evalTokens = 0
   let lastAssistantSig = ''
   let repeatCount = 0
+  // Canonical paths the model has read (or written) this run — gates edit/write.
+  const seenPaths = new Set<string>()
 
   for (let turn = 0; turn < MAX_TURNS; turn++) {
     let text = ''
@@ -70,7 +110,7 @@ export async function* runAgent(opts: RunAgentOpts): AsyncGenerator<AgentEvent, 
     if (signal) signal.addEventListener('abort', () => ac.abort(), { once: true })
 
     try {
-      for await (const chunk of chat(model, toOllamaMessages(history, system), ollamaTools, { signal: composedSignal, num_ctx, num_predict: NUM_PREDICT })) {
+      for await (const chunk of chat(model, toOllamaMessages(history, system), ollamaTools, { signal: composedSignal, num_ctx, num_predict: effort.num_predict, temperature: effort.temperature })) {
         if (signal?.aborted) break
         if (chunk.content) {
           text += chunk.content
@@ -199,6 +239,19 @@ export async function* runAgent(opts: RunAgentOpts): AsyncGenerator<AgentEvent, 
         continue
       }
 
+      const guard = readGuard(use.name, use.input, seenPaths)
+      if (guard) {
+        const r: ToolResultBlock = {
+          type: 'tool_result',
+          tool_use_id: use.id,
+          content: guard,
+          is_error: true,
+        }
+        results.push(r)
+        yield { type: 'tool-result', block: r }
+        continue
+      }
+
       // Hooks are best-effort: a throwing hook must never break the
       // tool_use → tool_result block invariant the model relies on.
       try { await hooks?.firePre(use) } catch { /* hook error ignored */ }
@@ -219,6 +272,7 @@ export async function* runAgent(opts: RunAgentOpts): AsyncGenerator<AgentEvent, 
           is_error: true,
         }
       }
+      if (!r.is_error) markSeen(use.name, use.input, seenPaths)
       try { await hooks?.firePost(use, r) } catch { /* hook error ignored */ }
       results.push(r)
       yield { type: 'tool-result', block: r }

--- a/src/permissions/policy.test.ts
+++ b/src/permissions/policy.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest'
+import { globToRegExp, subjectFor } from './policy.js'
+
+describe('globToRegExp', () => {
+  it('matches an exact literal', () => {
+    expect(globToRegExp('git status').test('git status')).toBe(true)
+    expect(globToRegExp('git status').test('git status -s')).toBe(false)
+  })
+
+  it('treats * as a wildcard run', () => {
+    expect(globToRegExp('npm test *').test('npm test src/a')).toBe(true)
+    expect(globToRegExp('npm test *').test('npm test')).toBe(false) // needs a space + something
+  })
+
+  it('treats ? as a single char', () => {
+    expect(globToRegExp('rm a?').test('rm ab')).toBe(true)
+    expect(globToRegExp('rm a?').test('rm abc')).toBe(false)
+  })
+
+  it('escapes regex metacharacters in the literal', () => {
+    // dots are literal, not "any char"
+    expect(globToRegExp('cat a.txt').test('cat a.txt')).toBe(true)
+    expect(globToRegExp('cat a.txt').test('cat aXtxt')).toBe(false)
+  })
+
+  it('anchors fully — no partial match', () => {
+    expect(globToRegExp('ls').test('ls -la')).toBe(false)
+    expect(globToRegExp('ls').test('please ls')).toBe(false)
+  })
+
+  it('documents the footgun: * spans shell separators', () => {
+    // A hand-added "npm test *" rule also matches a chained destructive command,
+    // because * compiles to .* with no separator awareness. Captured so a future
+    // change to tighten this breaks the test deliberately.
+    expect(globToRegExp('npm test *').test('npm test x; rm -rf /')).toBe(true)
+  })
+})
+
+describe('subjectFor', () => {
+  it('uses the command for run_bash', () => {
+    expect(subjectFor('run_bash', { command: 'ls -la' })).toBe('ls -la')
+  })
+
+  it('uses the path for file tools', () => {
+    expect(subjectFor('write_file', { path: 'src/a.ts' })).toBe('src/a.ts')
+  })
+
+  it('returns empty string when the subject field is missing', () => {
+    expect(subjectFor('run_bash', {})).toBe('')
+    expect(subjectFor('write_file', {})).toBe('')
+    expect(subjectFor('run_bash', null)).toBe('')
+  })
+})

--- a/src/permissions/policy.ts
+++ b/src/permissions/policy.ts
@@ -69,7 +69,7 @@ export function subjectFor(toolName: string, input: unknown): string {
 }
 
 /** Convert a glob (only `*` and `?` special) into an anchored RegExp. */
-function globToRegExp(glob: string): RegExp {
+export function globToRegExp(glob: string): RegExp {
   const escaped = glob.replace(/[.+^${}()|[\]\\]/g, '\\$&')
   const pattern = escaped.replace(/\*/g, '.*').replace(/\?/g, '.')
   return new RegExp(`^${pattern}$`)

--- a/src/prompt/context.test.ts
+++ b/src/prompt/context.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import {
+  findContextFile,
+  loadProjectContext,
+  CONTEXT_FILENAME,
+  MAX_CONTEXT_BYTES,
+} from './context.js'
+
+let root: string
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'miii-ctx-'))
+})
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true })
+})
+
+describe('findContextFile', () => {
+  it('finds MIII.md in cwd', () => {
+    const f = join(root, CONTEXT_FILENAME)
+    writeFileSync(f, 'hi')
+    expect(findContextFile(root)).toBe(f)
+  })
+
+  it('walks up to a parent dir', () => {
+    const sub = join(root, 'a', 'b')
+    mkdirSync(sub, { recursive: true })
+    const f = join(root, CONTEXT_FILENAME)
+    writeFileSync(f, 'hi')
+    expect(findContextFile(sub)).toBe(f)
+  })
+
+  it('nearest file wins over an ancestor', () => {
+    const sub = join(root, 'a')
+    mkdirSync(sub, { recursive: true })
+    writeFileSync(join(root, CONTEXT_FILENAME), 'far')
+    const near = join(sub, CONTEXT_FILENAME)
+    writeFileSync(near, 'near')
+    expect(findContextFile(sub)).toBe(near)
+  })
+
+  it('stops at the repo root (.git) without ascending past it', () => {
+    const repo = join(root, 'repo')
+    const sub = join(repo, 'pkg')
+    mkdirSync(sub, { recursive: true })
+    mkdirSync(join(repo, '.git'), { recursive: true })
+    // File lives ABOVE the repo root — must not be found.
+    writeFileSync(join(root, CONTEXT_FILENAME), 'outside')
+    expect(findContextFile(sub)).toBeNull()
+  })
+
+  it('returns null when no file exists', () => {
+    expect(findContextFile(root)).toBeNull()
+  })
+})
+
+describe('loadProjectContext', () => {
+  it('returns empty when no file', () => {
+    expect(loadProjectContext(root)).toEqual({ content: '', source: null, truncated: false })
+  })
+
+  it('loads file content', () => {
+    const f = join(root, CONTEXT_FILENAME)
+    writeFileSync(f, 'use tabs')
+    const c = loadProjectContext(root)
+    expect(c.content).toBe('use tabs')
+    expect(c.source).toBe(f)
+    expect(c.truncated).toBe(false)
+  })
+
+  it('treats an empty file as no content but records source', () => {
+    const f = join(root, CONTEXT_FILENAME)
+    writeFileSync(f, '')
+    const c = loadProjectContext(root)
+    expect(c.content).toBe('')
+    expect(c.source).toBe(f)
+  })
+
+  it('truncates oversized files', () => {
+    const f = join(root, CONTEXT_FILENAME)
+    writeFileSync(f, 'x'.repeat(MAX_CONTEXT_BYTES + 1000))
+    const c = loadProjectContext(root)
+    expect(c.truncated).toBe(true)
+    expect(Buffer.byteLength(c.content, 'utf8')).toBeLessThanOrEqual(MAX_CONTEXT_BYTES)
+  })
+})

--- a/src/prompt/context.ts
+++ b/src/prompt/context.ts
@@ -1,0 +1,54 @@
+import { existsSync, readFileSync, statSync } from 'fs'
+import { dirname, join } from 'path'
+
+/** Filename users drop in their project to steer miii, analogous to CLAUDE.md. */
+export const CONTEXT_FILENAME = 'MIII.md'
+
+/** Hard cap so an oversized file cannot blow the context window. */
+export const MAX_CONTEXT_BYTES = 32 * 1024
+
+export interface ProjectContext {
+  /** File body, possibly truncated. Empty string when no file was found. */
+  content: string
+  /** Absolute path of the loaded file, or null when none found. */
+  source: string | null
+  /** True when content was clipped to MAX_CONTEXT_BYTES. */
+  truncated: boolean
+}
+
+const EMPTY: ProjectContext = { content: '', source: null, truncated: false }
+
+/**
+ * Walk up from `cwd` to the filesystem root looking for MIII.md. Stops at the
+ * first match (nearest to cwd wins) or at a directory containing `.git` (repo
+ * boundary) — whichever comes first. Project-scoped only; no global lookup.
+ */
+export function findContextFile(cwd: string): string | null {
+  let dir = cwd
+  for (;;) {
+    const candidate = join(dir, CONTEXT_FILENAME)
+    if (existsSync(candidate)) return candidate
+    // Stop after checking the repo root for the file.
+    if (existsSync(join(dir, '.git'))) return null
+    const parent = dirname(dir)
+    if (parent === dir) return null
+    dir = parent
+  }
+}
+
+/** Load and read MIII.md for `cwd`. Never throws — read failures yield EMPTY. */
+export function loadProjectContext(cwd: string): ProjectContext {
+  const source = findContextFile(cwd)
+  if (!source) return EMPTY
+  try {
+    if (statSync(source).size === 0) return { ...EMPTY, source }
+    const raw = readFileSync(source, 'utf8')
+    if (Buffer.byteLength(raw, 'utf8') > MAX_CONTEXT_BYTES) {
+      const clipped = Buffer.from(raw, 'utf8').subarray(0, MAX_CONTEXT_BYTES).toString('utf8')
+      return { content: clipped, source, truncated: true }
+    }
+    return { content: raw, source, truncated: false }
+  } catch {
+    return { ...EMPTY, source }
+  }
+}

--- a/src/prompt/system.ts
+++ b/src/prompt/system.ts
@@ -1,10 +1,24 @@
 import type { Tool } from '../tools/types.js'
+import type { ProjectContext } from './context.js'
+import { CONTEXT_FILENAME } from './context.js'
 
-export function buildSystemPrompt(tools: Tool[], cwd: string): string {
+export function buildSystemPrompt(tools: Tool[], cwd: string, project?: ProjectContext): string {
   const toolLines = tools.map((t) => `- ${t.name}: ${t.description}`).join('\n')
+  const projectSection =
+    project && project.content.trim()
+      ? `
+# ${CONTEXT_FILENAME} — project instructions (authoritative, read first)
+The user maintains ${CONTEXT_FILENAME} at ${project.source} to steer how you work in this project: conventions, commands, architecture, do's and don'ts. Treat it as direct instruction from the user, higher priority than your defaults. When it conflicts with a default rule below, ${CONTEXT_FILENAME} wins (except permissions and safety, which you never override).${project.truncated ? `\n(Note: file exceeded ${'32KB'} and was truncated.)` : ''}
+
+--- BEGIN ${CONTEXT_FILENAME} ---
+${project.content.trim()}
+--- END ${CONTEXT_FILENAME} ---
+`
+      : ''
   return `You are miii, a senior software engineer running in a terminal.
 
 Working directory: ${cwd}
+${projectSection}
 
 # Goal Understanding (read this first, every turn)
 Before acting on any request, extract and hold three things:

--- a/src/tools/edit_file.test.ts
+++ b/src/tools/edit_file.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from 'fs'
+import { join, relative } from 'path'
+import { edit_file, fuzzyRange, similarity } from './edit_file.js'
+
+describe('similarity', () => {
+  it('is 1 for identical (ws-trimmed) strings', () => {
+    expect(similarity('  foo ', 'foo')).toBe(1)
+  })
+  it('is 1 when both are empty', () => {
+    expect(similarity('   ', '')).toBe(1)
+  })
+  it('is low for disjoint strings', () => {
+    expect(similarity('abcd', 'wxyz')).toBe(0)
+  })
+})
+
+describe('fuzzyRange', () => {
+  it('finds a unique whitespace-tolerant match and returns its char range', () => {
+    const src = 'line one\n    const x = 1\nline three\n'
+    const r = fuzzyRange(src, 'const x = 1')
+    expect(r).not.toBeNull()
+    const [s, e] = r!
+    expect(src.slice(s, e)).toBe('    const x = 1')
+  })
+
+  it('returns null when the normalized block matches more than once', () => {
+    const src = 'a\n  dup\nb\n    dup\nc\n'
+    expect(fuzzyRange(src, 'dup')).toBeNull()
+  })
+
+  it('returns null when there is no match', () => {
+    expect(fuzzyRange('a\nb\nc\n', 'zzz')).toBeNull()
+  })
+})
+
+describe('edit_file handler', () => {
+  let dir: string
+  const rel = (abs: string) => relative(process.cwd(), abs)
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(process.cwd(), '.vitest-edit-'))
+  })
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  const seed = (name: string, content: string) => {
+    const abs = join(dir, name)
+    writeFileSync(abs, content, 'utf-8')
+    return rel(abs)
+  }
+
+  it('replaces a unique exact string', async () => {
+    const p = seed('a.txt', 'hello world\n')
+    const out = await edit_file.handler({ path: p, old_str: 'world', new_str: 'there' })
+    expect(out.is_error).toBeFalsy()
+    expect(readFileSync(join(dir, 'a.txt'), 'utf-8')).toBe('hello there\n')
+  })
+
+  it('errors when old_str is not unique and replace_all is unset', async () => {
+    const p = seed('a.txt', 'x x x')
+    const out = await edit_file.handler({ path: p, old_str: 'x', new_str: 'y' })
+    expect(out.is_error).toBe(true)
+    expect(out.content).toMatch(/not unique/)
+  })
+
+  it('replaces every occurrence with replace_all', async () => {
+    const p = seed('a.txt', 'x x x')
+    const out = await edit_file.handler({ path: p, old_str: 'x', new_str: 'y', replace_all: true })
+    expect(out.is_error).toBeFalsy()
+    expect(readFileSync(join(dir, 'a.txt'), 'utf-8')).toBe('y y y')
+    expect(out.content).toMatch(/3 occurrences/)
+  })
+
+  it('rejects an identical old_str/new_str no-op', async () => {
+    const p = seed('a.txt', 'abc')
+    const out = await edit_file.handler({ path: p, old_str: 'abc', new_str: 'abc' })
+    expect(out.is_error).toBe(true)
+    expect(out.content).toMatch(/identical/)
+  })
+
+  it('falls back to a unique whitespace-tolerant match', async () => {
+    // File is tab-indented; the model's old_str uses spaces, so the exact
+    // indexOf misses and the whitespace-tolerant path takes over.
+    const p = seed('a.py', 'def f():\n\tfoo = 1\n')
+    const out = await edit_file.handler({ path: p, old_str: '    foo = 1', new_str: '\tfoo = 2' })
+    expect(out.is_error).toBeFalsy()
+    expect(out.content).toMatch(/whitespace-tolerant/)
+    expect(readFileSync(join(dir, 'a.py'), 'utf-8')).toBe('def f():\n\tfoo = 2\n')
+  })
+
+  it('on no match, returns the closest text in the file', async () => {
+    const p = seed('a.txt', 'const alpha = 1\nconst beta = 2\n')
+    const out = await edit_file.handler({ path: p, old_str: 'const alph = 1', new_str: 'x' })
+    expect(out.is_error).toBe(true)
+    expect(out.content).toMatch(/not found/)
+    expect(out.content).toMatch(/Closest text/)
+    expect(out.content).toMatch(/const alpha = 1/)
+  })
+})

--- a/src/tools/edit_file.ts
+++ b/src/tools/edit_file.ts
@@ -11,7 +11,7 @@ interface Input {
 }
 
 /** Cheap line-similarity: fraction of matching chars by position, ignoring leading/trailing ws. */
-function similarity(a: string, b: string): number {
+export function similarity(a: string, b: string): number {
   const x = a.trim()
   const y = b.trim()
   if (!x && !y) return 1
@@ -28,7 +28,7 @@ function similarity(a: string, b: string): number {
  * Returns the [start, end] char range in src of a unique whitespace-tolerant
  * match, or null if there is no match or more than one.
  */
-function fuzzyRange(src: string, old_str: string): [number, number] | null {
+export function fuzzyRange(src: string, old_str: string): [number, number] | null {
   const srcLines = src.split('\n')
   const oldLines = old_str.split('\n')
   const norm = (l: string) => l.trim()

--- a/src/tools/glob.ts
+++ b/src/tools/glob.ts
@@ -1,5 +1,6 @@
 import { execa } from 'execa'
 import { statSync } from 'fs'
+import { confinePath } from './paths.js'
 import type { Tool } from './types.js'
 
 // Sort newest-first; "what did I just touch" is the common intent.
@@ -47,7 +48,12 @@ export const glob: Tool<Input> = {
     required: ['pattern'],
   },
   handler: async ({ pattern, path, max_results }) => {
-    const root = path ?? process.cwd()
+    let root: string
+    try {
+      root = confinePath(path ?? '.')
+    } catch (err) {
+      return { content: err instanceof Error ? err.message : String(err), is_error: true }
+    }
     const limit = max_results ?? 500
 
     const tryRg = () =>

--- a/src/tools/grep.ts
+++ b/src/tools/grep.ts
@@ -1,4 +1,5 @@
 import { execa } from 'execa'
+import { confinePath } from './paths.js'
 import type { Tool } from './types.js'
 
 interface Input {
@@ -24,7 +25,12 @@ export const grep: Tool<Input> = {
     required: ['pattern'],
   },
   handler: async ({ pattern, path, glob, case_insensitive, max_results }) => {
-    const root = path ?? process.cwd()
+    let root: string
+    try {
+      root = confinePath(path ?? '.')
+    } catch (err) {
+      return { content: err instanceof Error ? err.message : String(err), is_error: true }
+    }
     const limit = max_results ?? 200
     const ci = case_insensitive === true || String(case_insensitive) === 'true'
 


### PR DESCRIPTION
Discover MIII.md by walking up from cwd to the repo root (nearest wins, stops at .git), inject it as authoritative project instructions ahead of defaults, with a 32KB truncation cap. Mirrors CLAUDE.md.

Also lands accumulated loop/tooling work: read-before-write guard, effort-driven temperature/num_predict, and policy/tool tweaks.