### PR TITLE
feat(session): summarize first exchange into title

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 maruakshay
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "LICENSE"
   ],
   "engines": {
     "node": ">=18"
@@ -28,13 +29,30 @@
     "type": "git",
     "url": "git+https://github.com/maruakshay/miii-cli.git"
   },
+  "homepage": "https://github.com/maruakshay/miii-cli#readme",
+  "bugs": {
+    "url": "https://github.com/maruakshay/miii-cli/issues"
+  },
   "keywords": [
     "cli",
     "ai",
+    "ai-agent",
+    "coding-agent",
+    "ai-coding-assistant",
     "ollama",
-    "agent",
+    "llm",
+    "local-llm",
+    "local-first",
+    "offline",
+    "privacy",
+    "terminal",
+    "tui",
     "ink",
-    "tui"
+    "agent",
+    "pair-programming",
+    "code-generation",
+    "llama-cpp",
+    "lm-studio"
   ],
   "license": "MIT",
   "dependencies": {

--- a/src/session/store.ts
+++ b/src/session/store.ts
@@ -62,7 +62,7 @@ function messageText(m: MiiMessage): string {
 function firstUserText(messages: MiiMessage[]): string {
   const first = messages.find((m) => m.role === 'user')
   if (!first) return 'untitled'
-  return messageText(first).trim().slice(0, 80) || 'untitled'
+  return flattenForTitle(messageText(first)).slice(0, 80) || 'untitled'
 }
 
 /** Read just the meta line (first line) of a session file. */
@@ -103,6 +103,16 @@ export function persistSession(id: string, messages: MiiMessage[], title?: strin
     lines.push(JSON.stringify({ type: 'message', message } satisfies MessageLine))
   }
   writeFileSync(sessionPath(id), lines.join('\n') + '\n', 'utf-8')
+}
+
+/**
+ * Update only a session's title, preserving whatever messages are currently on
+ * disk. Used by the background summariser, which may finish after more turns
+ * have been saved — reloading avoids clobbering them with a stale snapshot.
+ */
+export function setSessionTitle(id: string, title: string): void {
+  if (!readMeta(id)) return
+  persistSession(id, loadSession(id), title)
 }
 
 /** All saved sessions, most-recently-updated first. */
@@ -192,16 +202,53 @@ export function toDisplayMessages(history: MiiMessage[]): ChatMessage[] {
 }
 
 /**
- * Ask the model for a short title summarising the user's message.
- * Falls back to the truncated message text on error.
+ * Strip markup/pasted-blob noise to a flat, human-readable string: drop HTML
+ * tags, collapse whitespace. Used to clean both the summarizer input and its
+ * fallback so a pasted `<a href…>` blob never becomes a session title.
  */
-export async function summarizeMessage(model: string, text: string): Promise<string> {
-  const fallback = text.trim().slice(0, 80) || 'untitled'
+function flattenForTitle(text: string): string {
+  return text
+    .replace(/<[^>]*>/g, ' ') // strip HTML/XML tags
+    .replace(/[`*_#>|]/g, ' ') // strip markdown punctuation
+    .replace(/https?:\/\/\S+/g, ' ') // drop bare URLs
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+/** A model title is unusable if empty, still markup, or absurdly long. */
+function looksLikeJunkTitle(title: string): boolean {
+  return !title || /[<>]/.test(title) || title.length > 80
+}
+
+/**
+ * Ask the model for a short title summarising the conversation so far — the
+ * first user message plus the assistant's reply, Claude Code-style — rather
+ * than echoing the raw first message. Sanitises input before summarising and
+ * rejects markup-looking output, falling back to a flattened slice.
+ */
+export async function summarizeConversation(
+  model: string,
+  messages: MiiMessage[],
+): Promise<string> {
+  // Build "User: …\nAssistant: …" from the first user turn + first reply.
+  const parts: string[] = []
+  let sawUser = false
+  let sawAssistant = false
+  for (const m of messages) {
+    if (m.role === 'system') continue
+    const t = flattenForTitle(messageText(m))
+    if (!t) continue
+    if (m.role === 'user' && !sawUser) { parts.push(`User: ${t}`); sawUser = true }
+    else if (m.role === 'assistant' && !sawAssistant) { parts.push(`Assistant: ${t}`); sawAssistant = true }
+    if (sawUser && sawAssistant) break
+  }
+  const convo = parts.join('\n').slice(0, 2000)
+  const fallback = (parts[0]?.replace(/^User: /, '') ?? '').slice(0, 80) || 'untitled'
 
   const prompt =
-    'Summarize this user request as a short title, 3-6 words, no punctuation. ' +
+    'Summarize this conversation as a short title, 3-6 words, no punctuation. ' +
     'Reply with the title only.\n\n' +
-    `Request:\n${text.slice(0, 2000)}`
+    `Conversation:\n${convo}`
 
   try {
     let out = ''
@@ -213,7 +260,8 @@ export async function summarizeMessage(model: string, text: string): Promise<str
     )) {
       if (chunk.content) out += chunk.content
     }
-    return out.trim().split('\n').filter(Boolean)[0]?.trim() || fallback
+    const title = out.trim().split('\n').filter(Boolean)[0]?.trim() ?? ''
+    return looksLikeJunkTitle(title) ? fallback : title
   } catch {
     return fallback
   }

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -16,7 +16,7 @@ import { ModelsView } from './ModelsView.js'
 import { ProviderPicker } from './ProviderPicker.js'
 import { SessionsView } from './SessionsView.js'
 import { CommandPalette } from './CommandPalette.js'
-import { persistSession, newSessionId, type SessionMeta } from '../session/store.js'
+import { persistSession, setSessionTitle, summarizeConversation, newSessionId, type SessionMeta } from '../session/store.js'
 import { FilePicker, parseMention, searchFiles } from './FilePicker.js'
 import { ChatView } from './ChatView.js'
 import { useAgentRunner } from './hooks/useAgentRunner.js'
@@ -57,10 +57,34 @@ export function App() {
     checkForUpdate().then((v) => { if (v) setUpdateAvailable(v) })
   }, [])
 
+  // Tracks sessions whose LLM title has been generated, so we summarise once.
+  const titledSessions = useRef<Set<string>>(new Set())
+
   // Auto-save the active session to disk every time the agent history grows.
+  // Once the first assistant reply lands, summarise the exchange into a title
+  // (Claude Code-style) — background, best-effort, generated exactly once.
   useEffect(() => {
-    if (agent.agentHistory.length) persistSession(sessionId, agent.agentHistory)
-  }, [agent.agentHistory, sessionId])
+    const history = agent.agentHistory
+    if (!history.length) return
+    persistSession(sessionId, history)
+
+    if (
+      !titledSessions.current.has(sessionId) &&
+      cfg.model &&
+      history.some((m) => m.role === 'assistant')
+    ) {
+      titledSessions.current.add(sessionId)
+      const id = sessionId
+      const model = cfg.model
+      const snapshot = history
+      void (async () => {
+        try {
+          const title = await summarizeConversation(model, snapshot)
+          setSessionTitle(id, title)
+        } catch { /* best-effort */ }
+      })()
+    }
+  }, [agent.agentHistory, sessionId, cfg.model])
 
   // afterProvider=true forces the model picker (provider just changed); otherwise
   // a configured-and-available model goes straight to chat. Any load error bounces
@@ -137,7 +161,9 @@ export function App() {
     providers: filteredProviders, pickerQuery, setPickerQuery,
     agent,
     input, setInput, paletteCursor, setPaletteCursor, filePickerCursor, setFilePickerCursor,
-    sessionId, setSessionId, sessions, setSessions, setNotice,
+    sessionId, setSessionId,
+    onResumeSession: (id) => titledSessions.current.add(id),
+    sessions, setSessions, setNotice,
     switchProvider,
   })
 

--- a/src/ui/ChatView.tsx
+++ b/src/ui/ChatView.tsx
@@ -126,7 +126,13 @@ function FileEditBlock({
           <Box key={i} marginLeft={4}>
             <Text
               wrap="truncate"
-              backgroundColor={ln.sign === '+' ? '#13351f' : ln.sign === '-' ? '#3b1414' : undefined}
+              backgroundColor={
+                ln.sign === '-'
+                  ? '#3b1414'
+                  : ln.sign === '+' && label !== 'Write'
+                    ? '#13351f'
+                    : undefined
+              }
               dimColor={ln.sign === ' '}
             >
               {`${ln.sign} `}{code}

--- a/src/ui/hooks/useKeyboard.ts
+++ b/src/ui/hooks/useKeyboard.ts
@@ -11,7 +11,6 @@ import { parseMention, searchFiles } from '../FilePicker.js'
 import { toggleThinkingVisible } from '../ThinkingBlock.js'
 import { toggleToolExpanded } from '../ChatView.js'
 import {
-  summarizeMessage,
   persistSession,
   listSessions,
   loadSession,
@@ -114,6 +113,8 @@ interface KeyboardOptions {
   // sessions
   sessionId: string
   setSessionId: (id: string) => void
+  /** Called when an existing session is resumed; it already has a title. */
+  onResumeSession: (id: string) => void
   sessions: SessionMeta[]
   setSessions: (s: SessionMeta[]) => void
   setNotice: (s: string | null) => void
@@ -129,7 +130,7 @@ export function useKeyboard(opts: KeyboardOptions) {
     providers, pickerQuery, setPickerQuery,
     agent,
     input, setInput, paletteCursor, setPaletteCursor, filePickerCursor, setFilePickerCursor,
-    sessionId, setSessionId, sessions, setSessions, setNotice,
+    sessionId, setSessionId, onResumeSession, sessions, setSessions, setNotice,
     switchProvider,
   } = opts
 
@@ -268,6 +269,7 @@ export function useKeyboard(opts: KeyboardOptions) {
         setActiveToolResults([])
         setError(null)
         setSessionId(meta.id)
+        onResumeSession(meta.id)
         setNotice(`resumed · ${meta.title}`)
         setState('ready')
       }
@@ -350,19 +352,9 @@ export function useKeyboard(opts: KeyboardOptions) {
         } else if (trimmed) {
           setNotice(null)
           // Expand any paste chips back into their real text before sending.
+          // The session title is generated after the first assistant reply
+          // (see the auto-save effect in App.tsx), not from this raw message.
           const message = expandPastes(trimmed)
-          // On the first message of a session, summarise it into a title and
-          // persist (background, best-effort).
-          if (!agentHistory.length && cfg.model) {
-            const id = sessionId
-            const model = cfg.model
-            void (async () => {
-              try {
-                const title = await summarizeMessage(model, message)
-                persistSession(id, [{ role: 'user', content: message }], title)
-              } catch { /* best-effort */ }
-            })()
-          }
           sendMessage(message)
         }
         clearPasteStore()


### PR DESCRIPTION
Generate the session title from the first user+assistant exchange after the reply lands (Claude Code-style) instead of echoing the raw first message. Sanitize summarizer input so pasted HTML never leaks into a title, and update only the meta title on disk to avoid clobbering newer turns with a stale snapshot.

Also: green diff background only for Update (not Write), npm metadata (keywords, homepage, bugs) and LICENSE.