### PR TITLE
feat: implement grammar-constrained actions and generalized permissions

### DIFF
--- a/src/agent/adapter.test.ts
+++ b/src/agent/adapter.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest'
-import { parseTextToolCalls, blocksFromOllama, toOllamaMessages } from './adapter.js'
+import {
+  parseTextToolCalls,
+  blocksFromOllama,
+  toOllamaMessages,
+  parseGrammarAction,
+  streamRespondMessage,
+} from './adapter.js'
 import type { MiiMessage, ToolUse } from './types.js'
 
 const KNOWN = ['read_file', 'edit_file', 'run_bash']
@@ -125,5 +131,101 @@ describe('toOllamaMessages', () => {
     expect(out.map((m) => m.role)).toEqual(['system', 'assistant', 'tool', 'tool'])
     expect(out[2]).toMatchObject({ content: 'A', tool_call_id: 'toolu_1' })
     expect(out[3]).toMatchObject({ content: 'B', tool_call_id: 'toolu_2' })
+  })
+})
+
+describe('parseGrammarAction', () => {
+  const KNOWN = ['read_file', 'edit_file', 'run_bash', 'glob']
+
+  it('parses a tool action', () => {
+    const a = parseGrammarAction('{"name":"read_file","arguments":{"path":"a.ts"}}', KNOWN)
+    expect(a).toEqual({ kind: 'tool', name: 'read_file', arguments: { path: 'a.ts' } })
+  })
+
+  it('parses a respond action', () => {
+    const a = parseGrammarAction('{"name":"respond","arguments":{"message":"done"}}', KNOWN)
+    expect(a).toEqual({ kind: 'respond', message: 'done' })
+  })
+
+  it('tolerates surrounding whitespace/slop and extracts the object', () => {
+    const a = parseGrammarAction('  {"name":"glob","arguments":{"pattern":"**/*.ts"}}\n', KNOWN)
+    expect(a).toEqual({ kind: 'tool', name: 'glob', arguments: { pattern: '**/*.ts' } })
+  })
+
+  it('extracts a JSON object embedded in leading prose', () => {
+    const a = parseGrammarAction('here:{"name":"run_bash","arguments":{"command":"ls"}}', KNOWN)
+    expect(a).toEqual({ kind: 'tool', name: 'run_bash', arguments: { command: 'ls' } })
+  })
+
+  it('rejects an unknown tool name', () => {
+    expect(parseGrammarAction('{"name":"nope","arguments":{}}', KNOWN)).toBeNull()
+  })
+
+  it('respond is always accepted even though it is not a tool name', () => {
+    const a = parseGrammarAction('{"name":"respond","arguments":{"message":"hi"}}', KNOWN)
+    expect(a).toEqual({ kind: 'respond', message: 'hi' })
+  })
+
+  it('defaults a missing respond message to empty string', () => {
+    const a = parseGrammarAction('{"name":"respond","arguments":{}}', KNOWN)
+    expect(a).toEqual({ kind: 'respond', message: '' })
+  })
+
+  it('defaults missing arguments to an empty object', () => {
+    const a = parseGrammarAction('{"name":"read_file"}', KNOWN)
+    expect(a).toEqual({ kind: 'tool', name: 'read_file', arguments: {} })
+  })
+
+  it('returns null for empty input', () => {
+    expect(parseGrammarAction('', KNOWN)).toBeNull()
+  })
+
+  it('returns null for non-JSON garbage', () => {
+    expect(parseGrammarAction('not json at all', KNOWN)).toBeNull()
+  })
+
+  it('returns null when name is missing', () => {
+    expect(parseGrammarAction('{"arguments":{"path":"a"}}', KNOWN)).toBeNull()
+  })
+})
+
+describe('streamRespondMessage', () => {
+  it('returns null before the action is known to be respond', () => {
+    expect(streamRespondMessage('{"name":"read')).toBeNull()
+    expect(streamRespondMessage('{"name":"read_file","arguments":{"path":"a"}}')).toBeNull()
+  })
+
+  it('returns null once respond is known but message string has not started', () => {
+    expect(streamRespondMessage('{"name":"respond","arguments":{')).toBeNull()
+  })
+
+  it('decodes a partial message as incomplete', () => {
+    const r = streamRespondMessage('{"name":"respond","arguments":{"message":"hello wor')
+    expect(r).toEqual({ message: 'hello wor', complete: false })
+  })
+
+  it('marks the message complete at the closing quote', () => {
+    const r = streamRespondMessage('{"name":"respond","arguments":{"message":"done"}}')
+    expect(r).toEqual({ message: 'done', complete: true })
+  })
+
+  it('decodes standard escapes', () => {
+    const r = streamRespondMessage('{"name":"respond","arguments":{"message":"a\\nb\\t\\"c\\""}}')
+    expect(r).toEqual({ message: 'a\nb\t"c"', complete: true })
+  })
+
+  it('waits on an incomplete trailing backslash (no wrong char)', () => {
+    const r = streamRespondMessage('{"name":"respond","arguments":{"message":"line\\')
+    expect(r).toEqual({ message: 'line', complete: false })
+  })
+
+  it('waits on an incomplete \\u escape', () => {
+    const r = streamRespondMessage('{"name":"respond","arguments":{"message":"x\\u00')
+    expect(r).toEqual({ message: 'x', complete: false })
+  })
+
+  it('decodes a complete \\u escape', () => {
+    const r = streamRespondMessage('{"name":"respond","arguments":{"message":"x\\u0041y"}}')
+    expect(r).toEqual({ message: 'xAy', complete: true })
   })
 })

--- a/src/agent/adapter.ts
+++ b/src/agent/adapter.ts
@@ -136,6 +136,95 @@ function extractFirstJsonObject(s: string): { json: string; start: number; end: 
   return null
 }
 
+export type GrammarAction =
+  | { kind: 'respond'; message: string }
+  | { kind: 'tool'; name: string; arguments: Record<string, unknown> }
+
+/**
+ * Parse a grammar-constrained action object from assistant content. The decoder
+ * guarantees one well-formed JSON object of the shape
+ *   { "name": "<tool|respond>", "arguments": { ... } }
+ * but we stay defensive: tolerate leading/trailing slop and unknown names.
+ */
+export function parseGrammarAction(
+  content: string,
+  knownToolNames: string[],
+): GrammarAction | null {
+  if (!content) return null
+  let raw = content.trim()
+  if (!raw.startsWith('{')) {
+    const found = extractFirstJsonObject(raw)
+    if (!found) return null
+    raw = found.json
+  }
+  let obj: Record<string, unknown>
+  try {
+    obj = JSON.parse(raw) as Record<string, unknown>
+  } catch {
+    const found = extractFirstJsonObject(raw)
+    if (!found) return null
+    try {
+      obj = JSON.parse(found.json) as Record<string, unknown>
+    } catch {
+      return null
+    }
+  }
+  const name = typeof obj.name === 'string' ? obj.name : undefined
+  const args = (obj.arguments ?? {}) as Record<string, unknown>
+  if (!name) return null
+  if (name === 'respond') {
+    const message = typeof args.message === 'string' ? args.message : ''
+    return { kind: 'respond', message }
+  }
+  if (!knownToolNames.includes(name)) return null
+  return { kind: 'tool', name, arguments: args }
+}
+
+/**
+ * Incrementally decode the `message` of a `respond` action from a partial
+ * content buffer, so the final answer can stream live instead of appearing all
+ * at once when the JSON closes. Returns null until the buffer reveals this is a
+ * `respond` action and the message string has begun; otherwise the decoded text
+ * so far plus whether the closing quote has been seen.
+ *
+ * Pure and idempotent: the loop re-runs it on the growing buffer each chunk and
+ * emits only the newly-decoded tail. It stops before any incomplete trailing
+ * escape (e.g. a `\` or half-written `\uXXXX`) so a partial token never produces
+ * a wrong character.
+ */
+export function streamRespondMessage(text: string): { message: string; complete: boolean } | null {
+  if (!/"name"\s*:\s*"respond"/.test(text)) return null
+  const m = text.match(/"message"\s*:\s*"/)
+  if (!m || m.index == null) return null
+  const start = m.index + m[0].length
+  const escapes: Record<string, string> = {
+    n: '\n', t: '\t', r: '\r', b: '\b', f: '\f', '"': '"', '\\': '\\', '/': '/',
+  }
+  let out = ''
+  let i = start
+  while (i < text.length) {
+    const ch = text[i]
+    if (ch === '"') return { message: out, complete: true }
+    if (ch === '\\') {
+      const nx = text[i + 1]
+      if (nx === undefined) break // incomplete escape — wait for more
+      if (nx === 'u') {
+        const hex = text.slice(i + 2, i + 6)
+        if (hex.length < 4) break // incomplete \uXXXX — wait
+        out += String.fromCharCode(parseInt(hex, 16))
+        i += 6
+        continue
+      }
+      out += escapes[nx] ?? nx
+      i += 2
+      continue
+    }
+    out += ch
+    i++
+  }
+  return { message: out, complete: false }
+}
+
 export function blocksFromOllama(
   text: string,
   tool_calls: RawToolCall[] | undefined,

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -1,5 +1,6 @@
 import { existsSync } from 'fs'
-import { chat } from '../llm/client.js'
+import { chat, providerName, modelParamCountB } from '../llm/client.js'
+import { buildToolGrammar } from '../llm/grammar.js'
 import { confinePath } from '../tools/paths.js'
 import { TOOLS, getTool, toOllamaTools } from '../tools/registry.js'
 import { validateInput } from '../tools/validate.js'
@@ -8,7 +9,13 @@ import { loadProjectContext } from '../prompt/context.js'
 import { check, type PermissionContext } from '../permissions/policy.js'
 import { loadConfig, EFFORT_OPTIONS } from '../config.js'
 import { HookBus } from '../hooks/bus.js'
-import { toOllamaMessages, blocksFromOllama } from './adapter.js'
+import {
+  toOllamaMessages,
+  blocksFromOllama,
+  parseGrammarAction,
+  streamRespondMessage,
+  mintToolUseId,
+} from './adapter.js'
 import type {
   MiiMessage,
   AgentEvent,
@@ -20,6 +27,11 @@ import type {
 const MAX_TURNS = 25
 const REPEAT_TAIL = 120
 const REPEAT_KILL = 4
+// Constrained decoding helps small models (mangled tool JSON) but adds nothing —
+// and can slightly hurt reasoning — for large ones that already tool-call cleanly.
+// At/below this parameter count (billions) we enable the grammar. Unknown size
+// (null) errs toward enabling, since the local default is usually a small model.
+const GRAMMAR_MAX_PARAMS_B = 14
 
 /**
  * Harness-enforced read-before-write. The system prompt asks the model to read
@@ -78,8 +90,19 @@ export interface RunAgentOpts {
 export async function* runAgent(opts: RunAgentOpts): AsyncGenerator<AgentEvent, MiiMessage[]> {
   const { model, cwd, permissions, hooks, signal, num_ctx } = opts
   const startTime = Date.now()
-  const system = buildSystemPrompt(TOOLS, cwd, loadProjectContext(cwd))
+  // Constrained decoding: force every assistant turn into a valid action object
+  // via a grammar (see llm/grammar.ts), replacing native tool-calling and
+  // surfacing the action as JSON in content (parsed below). Auto-gated — only for
+  // Ollama, and only for small models that actually need it (param-count probe).
+  let useGrammar = false
+  if (providerName() === 'ollama') {
+    const params = await modelParamCountB(model)
+    useGrammar = params == null || params <= GRAMMAR_MAX_PARAMS_B
+  }
+  const system = buildSystemPrompt(TOOLS, cwd, loadProjectContext(cwd), useGrammar)
+  const grammar = useGrammar ? buildToolGrammar(TOOLS) : undefined
   const ollamaTools = toOllamaTools(TOOLS)
+  const toolNames = TOOLS.map((t) => t.name)
   // Effort drives temperature + output cap. high → num_predict -1 (unlimited),
   // which ollama.chat omits so the model runs to its own stop.
   const effort = EFFORT_OPTIONS[loadConfig().effort ?? 'medium']
@@ -99,6 +122,11 @@ export async function* runAgent(opts: RunAgentOpts): AsyncGenerator<AgentEvent, 
   for (let turn = 0; turn < MAX_TURNS; turn++) {
     let text = ''
     let tool_calls: Array<{ function: { name: string; arguments: Record<string, unknown> } }> | undefined
+    // Grammar mode: the JSON action streams as content. For a `respond` action we
+    // decode its message incrementally and surface it live; respondEmitted tracks
+    // how much we have already yielded so each chunk emits only the new tail.
+    let respondEmitted = 0
+    let streamedRespond = false
 
     let lastTail = ''
     let tailRepeats = 0
@@ -110,11 +138,25 @@ export async function* runAgent(opts: RunAgentOpts): AsyncGenerator<AgentEvent, 
     if (signal) signal.addEventListener('abort', () => ac.abort(), { once: true })
 
     try {
-      for await (const chunk of chat(model, toOllamaMessages(history, system), ollamaTools, { signal: composedSignal, num_ctx, num_predict: effort.num_predict, temperature: effort.temperature })) {
+      for await (const chunk of chat(model, toOllamaMessages(history, system), useGrammar ? undefined : ollamaTools, { signal: composedSignal, num_ctx, num_predict: effort.num_predict, temperature: effort.temperature, format: grammar })) {
         if (signal?.aborted) break
         if (chunk.content) {
           text += chunk.content
-          yield { type: 'text-delta', text: chunk.content }
+          // Native mode: stream prose directly. Grammar mode: content is a JSON
+          // action — stay silent for tool calls, but stream a `respond` message
+          // live as its string value arrives.
+          if (!useGrammar) {
+            yield { type: 'text-delta', text: chunk.content }
+          } else {
+            const r = streamRespondMessage(text)
+            if (r) {
+              streamedRespond = true
+              if (r.message.length > respondEmitted) {
+                yield { type: 'text-delta', text: r.message.slice(respondEmitted) }
+                respondEmitted = r.message.length
+              }
+            }
+          }
           if (text.length >= REPEAT_TAIL) {
             const tail = text.slice(-REPEAT_TAIL)
             if (tail === lastTail) {
@@ -165,7 +207,21 @@ export async function* runAgent(opts: RunAgentOpts): AsyncGenerator<AgentEvent, 
       return history
     }
 
-    const blocks = blocksFromOllama(text, tool_calls, TOOLS.map((t) => t.name))
+    let blocks: ContentBlock[]
+    if (useGrammar) {
+      const action = parseGrammarAction(text, toolNames)
+      if (action?.kind === 'tool') {
+        blocks = [{ type: 'tool_use', id: mintToolUseId(), name: action.name, input: action.arguments }]
+      } else {
+        // respond action (or unparseable fallback) ends the turn with prose.
+        const message = action?.kind === 'respond' ? action.message : text.trim()
+        // Already streamed live above? Don't double-emit — just record the block.
+        if (message && !streamedRespond) yield { type: 'text-delta', text: message }
+        blocks = message ? [{ type: 'text', text: message }] : []
+      }
+    } else {
+      blocks = blocksFromOllama(text, tool_calls, toolNames)
+    }
     const tool_uses = blocks.filter((b): b is ToolUse => b.type === 'tool_use')
 
     history.push({ role: 'assistant', content: blocks })

--- a/src/llm/client.ts
+++ b/src/llm/client.ts
@@ -37,6 +37,27 @@ export async function modelContext(model: string): Promise<number> {
     : openai.modelContext(entry, model)
 }
 
+// Per-session memo of model parameter counts. Keyed by host+model so switching
+// provider or model never returns a stale value. Cached null is intentional: an
+// unknown size should not re-probe `show` every turn.
+const paramCountCache = new Map<string, number | null>()
+
+/**
+ * Parameter count in billions, or null if unknown / not an Ollama provider.
+ * Drives the constrained-decoding auto-gate in the agent loop. Memoized per
+ * session — `show` metadata does not change while the process runs.
+ */
+export async function modelParamCountB(model: string): Promise<number | null> {
+  const { entry } = active()
+  if (entry.type !== 'ollama') return null
+  const key = `${entry.baseUrl}:${model}`
+  const cached = paramCountCache.get(key)
+  if (cached !== undefined) return cached
+  const params = await ollama.paramCountB(entry, model)
+  paramCountCache.set(key, params)
+  return params
+}
+
 export async function* chat(
   model: string,
   messages: OllamaMessage[],

--- a/src/llm/grammar.test.ts
+++ b/src/llm/grammar.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest'
+import { buildToolGrammar, RESPOND_ACTION } from './grammar.js'
+import type { Tool } from '../tools/types.js'
+
+const fakeTools: Tool[] = [
+  {
+    name: 'read_file',
+    description: 'Read a file',
+    input_schema: {
+      type: 'object',
+      properties: {
+        path: { type: 'string', description: 'File path' },
+        limit: { type: 'number', description: 'Max lines' },
+      },
+      required: ['path'],
+    },
+    handler: async () => ({ content: '' }),
+  },
+  {
+    name: 'pick',
+    description: 'Pick a mode',
+    input_schema: {
+      type: 'object',
+      properties: {
+        mode: { type: 'string', description: 'Mode', enum: ['a', 'b'] },
+      },
+    },
+    handler: async () => ({ content: '' }),
+  },
+]
+
+type Branch = {
+  type: string
+  additionalProperties: boolean
+  required: string[]
+  properties: {
+    name: { const: string }
+    arguments: {
+      type: string
+      additionalProperties: boolean
+      required?: string[]
+      properties: Record<string, { type: string; enum?: string[] }>
+    }
+  }
+}
+
+function branches(): Branch[] {
+  return buildToolGrammar(fakeTools).oneOf as Branch[]
+}
+
+describe('buildToolGrammar', () => {
+  it('emits one branch per tool plus a respond branch', () => {
+    const b = branches()
+    expect(b).toHaveLength(fakeTools.length + 1)
+    expect(b.map((x) => x.properties.name.const)).toEqual(['read_file', 'pick', RESPOND_ACTION])
+  })
+
+  it('discriminates only at the root oneOf (no sibling properties)', () => {
+    const g = buildToolGrammar(fakeTools) as Record<string, unknown>
+    expect(Object.keys(g)).toEqual(['oneOf'])
+  })
+
+  it('pins each branch name with const and requires name + arguments', () => {
+    for (const br of branches()) {
+      expect(br.type).toBe('object')
+      expect(br.additionalProperties).toBe(false)
+      expect(br.required).toEqual(['name', 'arguments'])
+      expect(typeof br.properties.name.const).toBe('string')
+    }
+  })
+
+  it('locks down args: additionalProperties false on every branch', () => {
+    for (const br of branches()) {
+      expect(br.properties.arguments.additionalProperties).toBe(false)
+    }
+  })
+
+  it("carries a tool's required args through", () => {
+    const readBranch = branches().find((b) => b.properties.name.const === 'read_file')!
+    expect(readBranch.properties.arguments.required).toEqual(['path'])
+  })
+
+  it('omits required when the tool declares none', () => {
+    const pickBranch = branches().find((b) => b.properties.name.const === 'pick')!
+    expect(pickBranch.properties.arguments.required).toBeUndefined()
+  })
+
+  it('preserves arg types and enums but strips descriptions', () => {
+    const readArgs = branches()
+      .find((b) => b.properties.name.const === 'read_file')!
+      .properties.arguments.properties
+    expect(readArgs.path).toEqual({ type: 'string' })
+    expect(readArgs.limit).toEqual({ type: 'number' })
+
+    const pickArgs = branches()
+      .find((b) => b.properties.name.const === 'pick')!
+      .properties.arguments.properties
+    expect(pickArgs.mode).toEqual({ type: 'string', enum: ['a', 'b'] })
+  })
+
+  it('respond branch takes a required string message', () => {
+    const respond = branches().find((b) => b.properties.name.const === RESPOND_ACTION)!
+    expect(respond.properties.arguments.required).toEqual(['message'])
+    expect(respond.properties.arguments.properties.message).toEqual({ type: 'string' })
+  })
+})

--- a/src/llm/grammar.ts
+++ b/src/llm/grammar.ts
@@ -1,0 +1,78 @@
+import type { Tool } from '../tools/types.js'
+
+/**
+ * Constrained-decoding grammar for tool use, as an Ollama `format` JSON Schema.
+ * Ollama compiles this to a llama.cpp GBNF grammar and enforces it token-by-token,
+ * so even weak local models can only emit a well-formed action object.
+ *
+ * Shape is a discriminated union over `name` (one branch per tool, plus a
+ * `respond` finish action). llama.cpp cannot mix `properties` with `oneOf` at the
+ * same level, so the discrimination lives at the root `oneOf`; each branch is a
+ * standalone object whose `arguments` schema is that tool's exact input schema.
+ * `additionalProperties:false` (llama.cpp's default) blocks invented fields and
+ * produces a tighter, faster grammar.
+ *
+ * Every assistant turn is exactly one action:
+ *   { "name": "<tool>",  "arguments": { ...that tool's args } }
+ *   { "name": "respond", "arguments": { "message": "<final answer>" } }
+ */
+
+type JsonSchemaNode = Record<string, unknown>
+
+/** Strip prose-only keys (description) the grammar does not need; keep type/enum. */
+function argProperties(
+  props: Record<string, { type: string; description?: string; enum?: string[] }>,
+): Record<string, JsonSchemaNode> {
+  const out: Record<string, JsonSchemaNode> = {}
+  for (const [key, spec] of Object.entries(props)) {
+    const node: JsonSchemaNode = { type: spec.type }
+    if (spec.enum && spec.enum.length) node.enum = spec.enum
+    out[key] = node
+  }
+  return out
+}
+
+function toolBranch(tool: Tool): JsonSchemaNode {
+  const args: JsonSchemaNode = {
+    type: 'object',
+    additionalProperties: false,
+    properties: argProperties(tool.input_schema.properties),
+  }
+  if (tool.input_schema.required && tool.input_schema.required.length) {
+    args.required = tool.input_schema.required
+  }
+  return {
+    type: 'object',
+    additionalProperties: false,
+    required: ['name', 'arguments'],
+    properties: {
+      name: { const: tool.name },
+      arguments: args,
+    },
+  }
+}
+
+/** The finish action: lets the model end the turn with a plain-text answer. */
+export const RESPOND_ACTION = 'respond'
+
+function respondBranch(): JsonSchemaNode {
+  return {
+    type: 'object',
+    additionalProperties: false,
+    required: ['name', 'arguments'],
+    properties: {
+      name: { const: RESPOND_ACTION },
+      arguments: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['message'],
+        properties: { message: { type: 'string' } },
+      },
+    },
+  }
+}
+
+/** Build the `format` schema for the given tools (defaults handled by caller). */
+export function buildToolGrammar(tools: Tool[]): JsonSchemaNode {
+  return { oneOf: [...tools.map(toolBranch), respondBranch()] }
+}

--- a/src/llm/ollama.ts
+++ b/src/llm/ollama.ts
@@ -1,4 +1,4 @@
-import { Ollama, type Message, type Tool, type ChatResponse } from 'ollama'
+import { Ollama, type Message, type ChatResponse } from 'ollama'
 import { execFileSync } from 'child_process'
 import type { ProviderEntry } from '../config.js'
 import type { OllamaMessage, OllamaTool, ChatChunk, ChatOptions } from './types.js'
@@ -85,6 +85,38 @@ export async function modelContext(entry: ProviderEntry, model: string): Promise
   }
 }
 
+/**
+ * Parameter count in billions, or null if unknown. Used to auto-gate constrained
+ * decoding: small models mangle tool JSON and benefit from a grammar; large ones
+ * already emit clean tool_calls and lose nothing by skipping it. Reads `show`
+ * metadata (parameter_size string, then general.parameter_count) — metadata only,
+ * no generation, so it is cheap.
+ */
+export async function paramCountB(entry: ProviderEntry, model: string): Promise<number | null> {
+  try {
+    const info = await makeClient(entry).show({ model })
+    const details = info.details as { parameter_size?: string } | undefined
+    if (details?.parameter_size) {
+      const m = details.parameter_size.match(/([\d.]+)\s*([BM])/i)
+      if (m) {
+        const n = parseFloat(m[1])
+        if (!isNaN(n)) return m[2].toUpperCase() === 'M' ? n / 1000 : n
+      }
+    }
+    const modelInfo = info.model_info as unknown as Record<string, unknown> | undefined
+    if (modelInfo) {
+      const key = Object.keys(modelInfo).find((k) => k.endsWith('parameter_count'))
+      if (key) {
+        const val = Number(modelInfo[key])
+        if (!isNaN(val) && val > 0) return val / 1e9
+      }
+    }
+    return null
+  } catch {
+    return null
+  }
+}
+
 export async function* chat(
   entry: ProviderEntry,
   model: string,
@@ -105,15 +137,22 @@ export async function* chat(
       num_ctx: opts?.num_ctx ?? 8192,
     }
     if (numPredict !== undefined && numPredict > 0) options.num_predict = numPredict
-    stream = await client.chat({
+    // Constrained decoding and native tool-calling are mutually exclusive: when a
+    // grammar is supplied the action comes back as JSON in message.content, so we
+    // drop the tools array to avoid the model's tool-call template fighting it.
+    const req: Record<string, unknown> = {
       model,
       messages: messages as Message[],
-      tools: tools as Tool[] | undefined,
       stream: true,
       think: true,
       keep_alive: opts?.keep_alive ?? '10m',
       options,
-    } as unknown as Parameters<typeof client.chat>[0]) as unknown as AsyncIterable<ChatResponse>
+    }
+    if (opts?.format) req.format = opts.format
+    else if (tools) req.tools = tools
+    stream = (await client.chat(
+      req as unknown as Parameters<typeof client.chat>[0],
+    )) as unknown as AsyncIterable<ChatResponse>
   } catch (err) {
     if (signal?.aborted) return
     if (isConnectionError(err)) {

--- a/src/llm/types.ts
+++ b/src/llm/types.ts
@@ -42,4 +42,10 @@ export interface ChatOptions {
   num_ctx?: number
   keep_alive?: string
   signal?: AbortSignal
+  /**
+   * Ollama structured-output schema. When set, decoding is constrained to this
+   * JSON Schema (compiled to a llama.cpp grammar) and native tool-calling is not
+   * used — the action is returned as JSON in message.content.
+   */
+  format?: Record<string, unknown>
 }

--- a/src/permissions/policy.test.ts
+++ b/src/permissions/policy.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { globToRegExp, subjectFor } from './policy.js'
+import { globToRegExp, subjectFor, generalizeCommand, patternToPersist } from './policy.js'
 
 describe('globToRegExp', () => {
   it('matches an exact literal', () => {
@@ -33,6 +33,43 @@ describe('globToRegExp', () => {
     // because * compiles to .* with no separator awareness. Captured so a future
     // change to tighten this breaks the test deliberately.
     expect(globToRegExp('npm test *').test('npm test x; rm -rf /')).toBe(true)
+  })
+})
+
+describe('generalizeCommand', () => {
+  it('keeps only the program for non-wrapper commands', () => {
+    expect(generalizeCommand("git commit -m 'x'")).toBe('git *')
+    expect(generalizeCommand('node script.js')).toBe('node *')
+  })
+
+  it('keeps two tokens for wrapper programs', () => {
+    expect(generalizeCommand('npm run build')).toBe('npm run *')
+    expect(generalizeCommand('npm install left-pad')).toBe('npm install *')
+    expect(generalizeCommand('npx tsc --noEmit')).toBe('npx tsc *')
+    expect(generalizeCommand('brew list --versions')).toBe('brew list *')
+  })
+
+  it('falls back to one token when a wrapper has no subcommand', () => {
+    expect(generalizeCommand('npm')).toBe('npm *')
+  })
+
+  it('collapses repeated whitespace', () => {
+    expect(generalizeCommand('git   status')).toBe('git *')
+  })
+
+  it('generalizes the resulting glob to match later variants', () => {
+    expect(globToRegExp(generalizeCommand('git commit -m "a"')).test('git push origin')).toBe(true)
+    expect(globToRegExp(generalizeCommand('npm run build')).test('npm install x')).toBe(false)
+  })
+})
+
+describe('patternToPersist', () => {
+  it('generalizes run_bash commands', () => {
+    expect(patternToPersist('run_bash', "git commit -m 'x'")).toBe('git *')
+  })
+
+  it('leaves path subjects untouched', () => {
+    expect(patternToPersist('write_file', 'src/a.ts')).toBe('src/a.ts')
   })
 })
 

--- a/src/permissions/policy.ts
+++ b/src/permissions/policy.ts
@@ -68,6 +68,45 @@ export function subjectFor(toolName: string, input: unknown): string {
   return ''
 }
 
+/**
+ * Wrapper programs that dispatch to a subcommand. For these we keep the first
+ * two tokens (e.g. "npm run", "npx tsc") so the persisted rule scopes to that
+ * subcommand rather than the whole program.
+ */
+const WRAPPER_PROGRAMS = new Set([
+  'npm',
+  'npx',
+  'pnpm',
+  'yarn',
+  'brew',
+  'pip',
+  'pip3',
+  'cargo',
+  'docker',
+  'kubectl',
+  'go',
+])
+
+/**
+ * Turn a concrete command into a generalized glob to persist on "always".
+ * "git commit -m '...'" → "git *", "npm run build" → "npm run *",
+ * "npx tsc --noEmit" → "npx tsc *". Without this we would store the exact
+ * literal command and re-prompt on the next slightly different invocation.
+ */
+export function generalizeCommand(command: string): string {
+  const tokens = command.trim().split(/\s+/)
+  if (tokens.length === 0 || tokens[0] === '') return command
+  const prog = tokens[0]
+  const prefixLen = WRAPPER_PROGRAMS.has(prog) && tokens.length > 1 ? 2 : 1
+  const prefix = tokens.slice(0, prefixLen).join(' ')
+  return `${prefix} *`
+}
+
+/** The pattern to persist when the user answers "always" for a tool call. */
+export function patternToPersist(toolName: string, subject: string): string {
+  return toolName === 'run_bash' ? generalizeCommand(subject) : subject
+}
+
 /** Convert a glob (only `*` and `?` special) into an anchored RegExp. */
 export function globToRegExp(glob: string): RegExp {
   const escaped = glob.replace(/[.+^${}()|[\]\\]/g, '\\$&')
@@ -100,6 +139,6 @@ export async function check(
 
   const answer = await ctx.ask(toolName, input)
   if (answer === 'no') return 'deny'
-  if (answer === 'always') addRule(toolName, subject)
+  if (answer === 'always') addRule(toolName, patternToPersist(toolName, subject))
   return 'allow'
 }

--- a/src/prompt/system.ts
+++ b/src/prompt/system.ts
@@ -2,8 +2,22 @@ import type { Tool } from '../tools/types.js'
 import type { ProjectContext } from './context.js'
 import { CONTEXT_FILENAME } from './context.js'
 
-export function buildSystemPrompt(tools: Tool[], cwd: string, project?: ProjectContext): string {
+export function buildSystemPrompt(
+  tools: Tool[],
+  cwd: string,
+  project?: ProjectContext,
+  grammarMode = false,
+): string {
   const toolLines = tools.map((t) => `- ${t.name}: ${t.description}`).join('\n')
+  const actionProtocol = grammarMode
+    ? `
+# Action protocol (strict)
+Every reply is exactly ONE JSON action object, nothing else — no prose outside it, no markdown, no fences. Decoding is grammar-constrained, so malformed output is impossible; your only job is to choose the right action.
+  To use a tool: {"name": "<tool_name>", "arguments": { ...that tool's args }}
+  To give your final answer to the user: {"name": "respond", "arguments": {"message": "<your full answer here>"}}
+Call tools until the GOAL is met, then emit a single "respond" action with the complete answer. The "respond" action is the ONLY way to end the turn and talk to the user — never put your final answer in a tool call.
+`
+    : ''
   const projectSection =
     project && project.content.trim()
       ? `
@@ -29,6 +43,17 @@ Before acting on any request, extract and hold three things:
 If GAPS is non-empty, ask the minimum questions needed to fill them — one message, numbered list — before touching any file or running any command. Do not guess. Do not act on assumptions.
 
 Re-read GOAL before every tool call. If a tool call does not move toward GOAL, skip it.
+
+# Plan summary before acting (conditional)
+Write a brief plan BEFORE the first tool call ONLY when the work is non-trivial:
+  - Multi-step, OR touches multiple files, OR is destructive/hard to reverse, OR mixes investigation + change.
+SKIP the plan for trivial work — a single read, one small edit, a quick search, a direct question. Just act.
+When you do write one:
+  - One or two plain-text sentences naming what you will do and in what order.
+  - State the intent (the bug/feature/fix and the steps), not a tool-by-tool narration.
+  - Keep it short — the user reads this to follow along, not a spec.
+Then begin immediately with the first tool call. Do not wait for approval unless GAPS was non-empty or the work is destructive.
+This summary is the ONE allowed preamble. It does not override the Tool calls rule below: after this plan, emit tool calls directly with no further narration between them.
 
 # Attention: re-attend to goal at each step
 After each tool result, answer silently: "Does this result move me toward GOAL?"
@@ -79,7 +104,7 @@ Ask in a numbered list. One round of questions per turn. Then wait.
 # Tools
 You have access to the following tools. Call them via the function-calling interface.
 ${toolLines}
-
+${actionProtocol}
 # Loop semantics
 - When you need to act on the filesystem or run a command, emit a tool call.
 - After each tool result, decide: more tool calls, or a final plain-text answer.


### PR DESCRIPTION
- Add a strict action protocol and grammar-constrained parsing to eliminate malformed LLM outputs
- Implement command generalization for permissions (e.g., git commit -> git *) to reduce prompt fatigue
- Update system prompt to require structured plan summaries for non-trivial tasks
- Integrate grammar support into the LLM clients and agent loop