### PR TITLE
feat: native tool-calling + truncation guards for local models

### DIFF
--- a/src/agent/adapter.test.ts
+++ b/src/agent/adapter.test.ts
@@ -187,6 +187,31 @@ describe('parseGrammarAction', () => {
   it('returns null when name is missing', () => {
     expect(parseGrammarAction('{"arguments":{"path":"a"}}', KNOWN)).toBeNull()
   })
+
+  it('reads args from the parameters key', () => {
+    const a = parseGrammarAction('{"name":"read_file","parameters":{"path":"a.ts"}}', KNOWN)
+    expect(a).toEqual({ kind: 'tool', name: 'read_file', arguments: { path: 'a.ts' } })
+  })
+
+  it('reads args from the input key', () => {
+    const a = parseGrammarAction('{"name":"glob","input":{"pattern":"*.ts"}}', KNOWN)
+    expect(a).toEqual({ kind: 'tool', name: 'glob', arguments: { pattern: '*.ts' } })
+  })
+
+  it('reads bare top-level fields when no wrapper key is present', () => {
+    const a = parseGrammarAction('{"name":"read_file","path":"a.ts"}', KNOWN)
+    expect(a).toEqual({ kind: 'tool', name: 'read_file', arguments: { path: 'a.ts' } })
+  })
+
+  it('parses a JSON-encoded string of args', () => {
+    const a = parseGrammarAction('{"name":"run_bash","arguments":"{\\"command\\":\\"ls\\"}"}', KNOWN)
+    expect(a).toEqual({ kind: 'tool', name: 'run_bash', arguments: { command: 'ls' } })
+  })
+
+  it('reads a bare top-level respond message', () => {
+    const a = parseGrammarAction('{"name":"respond","message":"done"}', KNOWN)
+    expect(a).toEqual({ kind: 'respond', message: 'done' })
+  })
 })
 
 describe('streamRespondMessage', () => {

--- a/src/agent/adapter.ts
+++ b/src/agent/adapter.ts
@@ -170,8 +170,30 @@ export function parseGrammarAction(
     }
   }
   const name = typeof obj.name === 'string' ? obj.name : undefined
-  const args = (obj.arguments ?? {}) as Record<string, unknown>
   if (!name) return null
+  // Weak models vary how they attach args: a wrapper key (arguments /
+  // parameters / input / args), a JSON-encoded string in that key, or the
+  // fields placed bare at the top level alongside `name`. Accept all of them —
+  // requiring exactly `arguments` made the model loop, since a model that put
+  // fields at the top level could never satisfy the parser.
+  let args: Record<string, unknown>
+  const wrapped = obj.arguments ?? obj.parameters ?? obj.input ?? obj.args
+  if (typeof wrapped === 'string') {
+    try {
+      const parsed = JSON.parse(wrapped)
+      args = parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+        ? (parsed as Record<string, unknown>)
+        : {}
+    } catch {
+      args = {}
+    }
+  } else if (wrapped && typeof wrapped === 'object' && !Array.isArray(wrapped)) {
+    args = wrapped as Record<string, unknown>
+  } else {
+    // No wrapper key — treat the remaining top-level fields as the args.
+    const { name: _n, ...rest } = obj
+    args = rest
+  }
   if (name === 'respond') {
     const message = typeof args.message === 'string' ? args.message : ''
     return { kind: 'respond', message }

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -1,9 +1,9 @@
 import { existsSync } from 'fs'
-import { chat, providerName, modelParamCountB } from '../llm/client.js'
+import { chat } from '../llm/client.js'
 import { buildToolGrammar } from '../llm/grammar.js'
 import { confinePath } from '../tools/paths.js'
 import { TOOLS, getTool, toOllamaTools } from '../tools/registry.js'
-import { validateInput } from '../tools/validate.js'
+import { validateInput, exampleInput } from '../tools/validate.js'
 import { buildSystemPrompt } from '../prompt/system.js'
 import { loadProjectContext } from '../prompt/context.js'
 import { check, type PermissionContext } from '../permissions/policy.js'
@@ -27,11 +27,6 @@ import type {
 const MAX_TURNS = 25
 const REPEAT_TAIL = 120
 const REPEAT_KILL = 4
-// Constrained decoding helps small models (mangled tool JSON) but adds nothing —
-// and can slightly hurt reasoning — for large ones that already tool-call cleanly.
-// At/below this parameter count (billions) we enable the grammar. Unknown size
-// (null) errs toward enabling, since the local default is usually a small model.
-const GRAMMAR_MAX_PARAMS_B = 14
 
 /**
  * Harness-enforced read-before-write. The system prompt asks the model to read
@@ -55,6 +50,59 @@ function readGuard(name: string, input: unknown, seen: Set<string>): string | nu
   if (name === 'write_file' && !existsSync(abs)) return null
   const verb = name === 'edit_file' ? 'edit' : 'overwrite'
   return `Refusing to ${verb} ${p}: you have not read it this turn. Call read_file on ${p} first, then retry the ${name}.`
+}
+
+/**
+ * Some local models echo the full call envelope as the tool input, e.g.
+ *   { name: "write_file", arguments: { path, content } }
+ * instead of the bare { path, content }. Unwrap to the inner arguments so
+ * validation/handlers see the real fields — otherwise the model loops,
+ * re-emitting the same malformed call until the repeat-kill fires.
+ */
+function unwrapEnvelope(name: string, input: Record<string, unknown>): Record<string, unknown> {
+  if (!('arguments' in input)) return input
+  if ('name' in input && input.name !== name) return input
+  let args = input.arguments
+  if (typeof args === 'string') {
+    try { args = JSON.parse(args) } catch { return input }
+  }
+  if (args && typeof args === 'object' && !Array.isArray(args)) return args as Record<string, unknown>
+  return input
+}
+
+// Tools whose payload carries a large free-text field (file body / edit text).
+// These are the ones a weak local model mangles or gets cut off mid-write.
+const BIG_WRITE_TOOLS = new Set(['write_file', 'edit_file'])
+
+/**
+ * Guidance handed back when a big-write call can't run because its response was
+ * cut off (token cap) or mangled mid-write. Steers the model to split the work
+ * instead of re-emitting the same oversized call — which it otherwise loops on.
+ */
+function splitWriteHint(name: string, cause: 'truncated' | 'garbled'): string {
+  const lead =
+    cause === 'truncated'
+      ? `Your response was cut off at the output token limit, so this ${name} call is incomplete and was NOT run.`
+      : `Your ${name} call arrived with missing or garbled arguments — usually the response was cut off or mangled while writing a large value. It was NOT run.`
+  return (
+    `${lead} Do not resend the whole file in one call. Instead create the file ` +
+    `with write_file containing only the first portion, then append the rest ` +
+    `with successive edit_file calls. Keep each call small.`
+  )
+}
+
+/**
+ * After envelope-unwrapping, a big-write call that is still missing its key
+ * fields (no `path`, or write_file with no string `content`) is almost never a
+ * genuine shape mistake — it's a truncated/mangled write. Detect it so we can
+ * steer the model to split the work rather than emit a bare "path Required",
+ * which just makes it retry the same oversized call.
+ */
+function looksTruncatedWrite(name: string, input: Record<string, unknown>): boolean {
+  if (!BIG_WRITE_TOOLS.has(name)) return false
+  if (typeof input.path !== 'string' || !input.path) return true
+  if (name === 'write_file' && typeof input.content !== 'string') return true
+  return false
 }
 
 /** Record a path the model now knows the current state of (read or wrote). */
@@ -90,15 +138,11 @@ export interface RunAgentOpts {
 export async function* runAgent(opts: RunAgentOpts): AsyncGenerator<AgentEvent, MiiMessage[]> {
   const { model, cwd, permissions, hooks, signal, num_ctx } = opts
   const startTime = Date.now()
-  // Constrained decoding: force every assistant turn into a valid action object
-  // via a grammar (see llm/grammar.ts), replacing native tool-calling and
-  // surfacing the action as JSON in content (parsed below). Auto-gated — only for
-  // Ollama, and only for small models that actually need it (param-count probe).
-  let useGrammar = false
-  if (providerName() === 'ollama') {
-    const params = await modelParamCountB(model)
-    useGrammar = params == null || params <= GRAMMAR_MAX_PARAMS_B
-  }
+  // Constrained decoding via grammar (see llm/grammar.ts) is disabled — tool
+  // calls use native Ollama tool-calling, matching the simpler v0.1.15 behavior.
+  // The grammar path and its auto-gate (providerName/modelParamCountB probe)
+  // remain in the code; flip this back to the probe to re-enable for small models.
+  const useGrammar = false
   const system = buildSystemPrompt(TOOLS, cwd, loadProjectContext(cwd), useGrammar)
   const grammar = useGrammar ? buildToolGrammar(TOOLS) : undefined
   const ollamaTools = toOllamaTools(TOOLS)
@@ -127,10 +171,17 @@ export async function* runAgent(opts: RunAgentOpts): AsyncGenerator<AgentEvent, 
     // how much we have already yielded so each chunk emits only the new tail.
     let respondEmitted = 0
     let streamedRespond = false
+    // Reasoning models think THEN answer. Some providers still trickle a few
+    // thinking tokens after visible text has begun; surfacing them flips the UI
+    // back into "thinking" and wedges the spinner above the streaming answer
+    // (between the prior tool result and this turn's text). Once we emit visible
+    // text, drop the rest of this turn's thinking.
+    let emittedText = false
 
     let lastTail = ''
     let tailRepeats = 0
     let streamLooped = false
+    let truncated = false
     const ac = new AbortController()
     const composedSignal = signal
       ? (AbortSignal.any ? AbortSignal.any([signal, ac.signal]) : ac.signal)
@@ -146,12 +197,14 @@ export async function* runAgent(opts: RunAgentOpts): AsyncGenerator<AgentEvent, 
           // action — stay silent for tool calls, but stream a `respond` message
           // live as its string value arrives.
           if (!useGrammar) {
+            emittedText = true
             yield { type: 'text-delta', text: chunk.content }
           } else {
             const r = streamRespondMessage(text)
             if (r) {
               streamedRespond = true
               if (r.message.length > respondEmitted) {
+                emittedText = true
                 yield { type: 'text-delta', text: r.message.slice(respondEmitted) }
                 respondEmitted = r.message.length
               }
@@ -172,7 +225,7 @@ export async function* runAgent(opts: RunAgentOpts): AsyncGenerator<AgentEvent, 
             }
           }
         }
-        if (chunk.thinking) {
+        if (chunk.thinking && !emittedText) {
           yield { type: 'thinking-delta', text: chunk.thinking }
         }
         if (chunk.tool_calls && chunk.tool_calls.length > 0) {
@@ -181,6 +234,7 @@ export async function* runAgent(opts: RunAgentOpts): AsyncGenerator<AgentEvent, 
         if (chunk.done) {
           promptTokens += chunk.prompt_eval_count ?? 0
           evalTokens += chunk.eval_count ?? 0
+          if (chunk.done_reason === 'length') truncated = true
         }
       }
     } catch (err) {
@@ -226,6 +280,25 @@ export async function* runAgent(opts: RunAgentOpts): AsyncGenerator<AgentEvent, 
 
     history.push({ role: 'assistant', content: blocks })
 
+    // Output hit the token cap mid-stream. Any tool call here has truncated
+    // arguments (e.g. a half-written file `content`); executing it would write a
+    // corrupt file, and the partial args usually fail validation so the model
+    // just re-emits the same oversized call forever. Refuse to run it and tell
+    // the model to split the work into smaller writes instead of looping.
+    if (truncated && tool_uses.length > 0) {
+      const results: ToolResultBlock[] = tool_uses.map((use) => ({
+        type: 'tool_result' as const,
+        tool_use_id: use.id,
+        content: splitWriteHint(use.name, 'truncated'),
+        is_error: true,
+      }))
+      for (const u of tool_uses) yield { type: 'tool-use', block: u }
+      for (const r of results) yield { type: 'tool-result', block: r }
+      history.push({ role: 'user', content: results as ContentBlock[] })
+      yield { type: 'turn-end', stop_reason: 'tool_use' }
+      continue
+    }
+
     if (tool_uses.length === 0) {
       yield { type: 'turn-end', stop_reason: 'end_turn' }
       break
@@ -268,12 +341,19 @@ export async function* runAgent(opts: RunAgentOpts): AsyncGenerator<AgentEvent, 
         continue
       }
 
+      use.input = unwrapEnvelope(use.name, use.input)
       const invalid = validateInput(tool.input_schema, use.input)
       if (invalid) {
+        // Empty/garbled args on a big-write tool almost always means a
+        // truncated or mangled write, not a shape mistake — steer to splitting
+        // the work rather than retrying the same oversized call.
+        const content = looksTruncatedWrite(use.name, use.input)
+          ? splitWriteHint(use.name, 'garbled')
+          : `${invalid} for ${use.name}. Pass the arguments directly as the tool input — do NOT wrap them in {"name":...,"arguments":...}. Correct shape: ${exampleInput(tool.input_schema)}. Retry with all required fields.`
         const r: ToolResultBlock = {
           type: 'tool_result',
           tool_use_id: use.id,
-          content: `${invalid} for ${use.name}.`,
+          content,
           is_error: true,
         }
         results.push(r)

--- a/src/config.ts
+++ b/src/config.ts
@@ -30,9 +30,13 @@ export interface Config {
   lmstudioHost?: string
 }
 
+// num_predict caps the output tokens per turn. It must be large enough to hold a
+// full file written inline in a tool call — at 1k/2k whole-file writes (an HTML
+// page, a component) get truncated mid-`content`, leaving the tool args
+// incomplete so the call never validates and the model retries forever.
 export const EFFORT_OPTIONS: Record<Effort, { temperature: number; num_predict: number }> = {
-  low:    { temperature: 0.2, num_predict: 1024 },
-  medium: { temperature: 0.7, num_predict: 2048 },
+  low:    { temperature: 0.2, num_predict: 8192 },
+  medium: { temperature: 0.7, num_predict: 16384 },
   high:   { temperature: 1.0, num_predict: -1 },
 }
 

--- a/src/llm/ollama.ts
+++ b/src/llm/ollama.ts
@@ -185,6 +185,7 @@ export async function* chat(
         content: stripHarmony(chunk.message.content),
         thinking: stripHarmony((chunk.message as { thinking?: string }).thinking),
         done: chunk.done,
+        done_reason: (chunk as { done_reason?: string }).done_reason,
         tool_calls: chunk.message.tool_calls as ChatChunk['tool_calls'],
         prompt_eval_count: chunk.prompt_eval_count,
         eval_count: chunk.eval_count,

--- a/src/llm/openai.ts
+++ b/src/llm/openai.ts
@@ -126,6 +126,7 @@ export async function* chat(
     name?: string
     args: string
   }> = new Map()
+  let lastFinishReason: string | null | undefined
 
   const TIMEOUT_MS = 180000
   const timeoutSignal = AbortSignal.timeout(TIMEOUT_MS)
@@ -177,6 +178,7 @@ export async function* chat(
 
           const delta = choices[0].delta ?? {}
           const finishReason = choices[0].finish_reason
+          if (finishReason) lastFinishReason = finishReason
 
           if (delta.content) {
             yield { content: delta.content as string, done: false }
@@ -251,6 +253,9 @@ export async function* chat(
   yield {
     content: '',
     done: true,
+    // OpenAI signals a hit token cap as finish_reason 'length'; normalize to the
+    // Ollama spelling so the agent loop can detect truncation uniformly.
+    done_reason: lastFinishReason === 'length' ? 'length' : lastFinishReason ?? undefined,
     tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
   }
 }

--- a/src/llm/types.ts
+++ b/src/llm/types.ts
@@ -31,6 +31,9 @@ export interface ChatChunk {
   content: string
   thinking?: string
   done: boolean
+  // Why generation stopped, on the final (done) chunk. 'length' means the output
+  // hit the num_predict cap and was cut off — any inline tool args are partial.
+  done_reason?: string
   tool_calls?: OllamaToolCall[]
   prompt_eval_count?: number
   eval_count?: number

--- a/src/tools/edit_file.ts
+++ b/src/tools/edit_file.ts
@@ -107,7 +107,10 @@ export const edit_file: Tool<Input> = {
   handler: ({ path, old_str, new_str, replace_all }) => {
     try {
       if (old_str === new_str) {
-        return { content: `old_str and new_str are identical — nothing to change in ${path}.`, is_error: true }
+        return {
+          content: `old_str and new_str are identical — nothing to change in ${path}. If the file is already correct, do NOT edit again: finish with the respond action and tell the user it is done.`,
+          is_error: true,
+        }
       }
       const abs = confinePath(path)
       const src = readFileSync(abs, 'utf-8')

--- a/src/tools/validate.ts
+++ b/src/tools/validate.ts
@@ -30,6 +30,34 @@ function toZod(schema: JsonSchema): ZodTypeAny {
   return z.object(shape).passthrough()
 }
 
+/** Placeholder value for a property, by declared type — used in example shapes. */
+function exampleValue(spec: { type: string; enum?: string[] }): unknown {
+  if (spec.enum && spec.enum.length) return spec.enum[0]
+  switch (spec.type) {
+    case 'number':
+    case 'integer': return 0
+    case 'boolean': return false
+    case 'array': return []
+    case 'object': return {}
+    default: return '...'
+  }
+}
+
+/**
+ * A minimal valid-shape example for a schema, built from its required fields.
+ * Weak local models repeat the same malformed call when handed a bare error;
+ * showing the exact shape they must emit lets them self-correct next turn.
+ */
+export function exampleInput(schema: JsonSchema): string {
+  const required = schema.required ?? []
+  const obj: Record<string, unknown> = {}
+  for (const key of required) {
+    const spec = schema.properties[key]
+    if (spec) obj[key] = exampleValue(spec)
+  }
+  return JSON.stringify(obj)
+}
+
 /**
  * Validate a tool call's input against its declared input_schema.
  * Returns null on success, or a human-readable error string on failure.

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -266,14 +266,6 @@ export function App() {
             header={<WelcomeBlock model={cfg.model} activeCtx={activeCtx} effort={effort} cwd={cwd} />}
           />
 
-          {/* Async update check can resolve after the static banner is printed
-              (which then can't repaint), so surface it as a live-frame line. */}
-          {updateAvailable && (
-            <Box marginLeft={2} marginBottom={1}>
-              <Text color="yellow">{`↑ update available: v${updateAvailable} — run: miii --update`}</Text>
-            </Box>
-          )}
-
           {input.startsWith('/') && (
             <CommandPalette filter={input} cursor={paletteCursor} />
           )}

--- a/src/ui/ToolBlock.tsx
+++ b/src/ui/ToolBlock.tsx
@@ -1,5 +1,5 @@
 import { Box, Text } from 'ink'
-import { highlight } from 'cli-highlight'
+import { highlight, supportsLanguage } from 'cli-highlight'
 import type { ToolUseDisplay, ToolResultDisplay } from './types.js'
 import { useToolExpanded } from './toolExpand.js'
 import { countLines, truncate } from './layout.js'
@@ -33,7 +33,9 @@ function langFromPath(path: string): string | undefined {
 }
 
 function highlightLine(text: string, lang: string | undefined): string {
-  if (!lang) return text
+  // Guard unknown langs: cli-highlight logs a console warning before throwing,
+  // which the catch can't suppress and would spam once per diff line.
+  if (!lang || !supportsLanguage(lang)) return text
   try {
     return highlight(text, { language: lang, ignoreIllegals: true })
   } catch {

--- a/src/ui/markdown.ts
+++ b/src/ui/markdown.ts
@@ -1,6 +1,6 @@
 import { Marked } from 'marked'
 import { markedTerminal } from 'marked-terminal'
-import { highlight } from 'cli-highlight'
+import { highlight, supportsLanguage } from 'cli-highlight'
 import chalk from 'chalk'
 
 // Muted, low-glare palette — soft pastels over saturated brights so long
@@ -28,7 +28,10 @@ const theme = {
 // Fenced code blocks are syntax-highlighted via cli-highlight (already a dep,
 // same engine ChatView uses for diffs).
 function highlightCode(code: string, lang?: string): string {
-  if (!lang) return code
+  // Skip unknown languages: cli-highlight logs a noisy "Could not find the
+  // language" warning to the console *before* throwing, and the catch can't
+  // suppress that. Models fence plans/pseudo-langs (```plan), so guard first.
+  if (!lang || !supportsLanguage(lang)) return code
   try {
     return highlight(code, { language: lang, ignoreIllegals: true })
   } catch {


### PR DESCRIPTION
Disable grammar-constrained decoding by default; tool calls use native Ollama tool-calling, matching the simpler v0.1.15 behavior. Grammar path stays in the code behind a flag for re-enabling on small models.

Harden weak/local models against truncated and malformed tool calls:
- raise num_predict (low 8k, medium 16k) so inline whole-file writes aren't cut off mid-content
- detect done_reason 'length' (ollama + openai) and refuse partial tool calls, steering the model to split large writes
- unwrap call envelopes and accept varied arg shapes
- example-shape error messages so models self-correct
- guard cli-highlight against unknown fenced languages