### PR TITLE
feat: image paste for vision models

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 
 <p align="center">
   <a href="https://www.npmjs.com/package/miii-agent"><img src="https://img.shields.io/npm/v/miii-agent" alt="npm version"></a>
+  <a href="https://www.npmjs.com/package/miii-agent"><img src="https://img.shields.io/npm/dt/miii-agent" alt="npm total downloads"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="license"></a>
   <a href="https://nodejs.org"><img src="https://img.shields.io/badge/node-%3E%3D18-brightgreen" alt="node version"></a>
   <a href="https://ollama.com"><img src="https://img.shields.io/badge/powered%20by-Ollama-black" alt="powered by Ollama"></a>
@@ -68,6 +69,10 @@ It doesn't just chat, either — it decomposes the problem, calls tools, and che
   miii doctor                  # grade every installed model
   miii doctor qwen2.5-coder:7b # grade one
   ```
+- **🖼️ Paste images** — copy a screenshot and hit `Ctrl+V` to attach it to your message, or paste an image file path. Great for "why does this UI look broken?" or reading an error screenshot. **Needs a vision-capable model** (`llava`, `llama3.2-vision`, `qwen2-vl`, …) — text-only models silently ignore the image.
+  ```bash
+  ollama pull llava            # or llama3.2-vision
+  ```
 - **💧 Lossless output spill** — that 50K-line test log won't get truncated and leave the model guessing. miii spills the full output to disk and lets the model page through it. Nothing is ever lost.
 - **🔒 Permission-gated tools** — you approve what the agent can touch; "always" approvals persist. File tools are confined to your working directory.
 - **📄 `MIII.md`** — drop one in your repo to teach miii your conventions, build/test commands, and do's & don'ts. Same idea as `CLAUDE.md`, read every turn.
@@ -96,6 +101,7 @@ File tools (`read_file`, `write_file`, `edit_file`) reject `../` traversal and a
 |-----|--------|
 | `Enter` | Send prompt |
 | `@filename` | Attach file to context |
+| `Ctrl+V` | Paste clipboard image (needs a vision model) |
 | `/models` | Switch active model |
 | `/clear` | Reset conversation |
 | `Esc` | Stop generation or tool run |

--- a/src/agent/adapter.ts
+++ b/src/agent/adapter.ts
@@ -17,7 +17,9 @@ export function toOllamaMessages(history: MiiMessage[], system: string): OllamaM
 
   for (const msg of history) {
     if (typeof msg.content === 'string') {
-      out.push({ role: msg.role === 'system' ? 'system' : msg.role, content: msg.content })
+      const om: OllamaMessage = { role: msg.role === 'system' ? 'system' : msg.role, content: msg.content }
+      if (msg.role === 'user' && msg.images && msg.images.length > 0) om.images = msg.images
+      out.push(om)
       continue
     }
 

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -114,6 +114,8 @@ export interface RunAgentOpts {
   cwd: string
   history: MiiMessage[]
   userText: string
+  /** Base64-encoded images attached to this turn's user message. */
+  images?: string[]
   permissions: PermissionContext
   hooks?: HookBus
   signal?: AbortSignal
@@ -143,7 +145,11 @@ export async function* runAgent(opts: RunAgentOpts): AsyncGenerator<AgentEvent, 
 
   const history: MiiMessage[] = [
     ...opts.history,
-    { role: 'user', content: opts.userText },
+    {
+      role: 'user',
+      content: opts.userText,
+      ...(opts.images && opts.images.length > 0 ? { images: opts.images } : {}),
+    },
   ]
 
   let promptTokens = 0

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -22,6 +22,8 @@ export type ContentBlock = TextBlock | ToolUse | ToolResultBlock
 export interface MiiMessage {
   role: 'user' | 'assistant' | 'system'
   content: string | ContentBlock[]
+  /** Base64-encoded images attached to a user message (vision models). */
+  images?: string[]
 }
 
 export type StopReason = 'end_turn' | 'tool_use'

--- a/src/llm/ollama.ts
+++ b/src/llm/ollama.ts
@@ -49,6 +49,21 @@ function isConnectionError(err: unknown): boolean {
   return msg.includes('ECONNREFUSED') || msg.includes('fetch failed') || msg.includes('connect')
 }
 
+// Ollama rejects images sent to a text-only model with "this model does not
+// support image input". Rewrite it into an actionable, non-cryptic message.
+function isNoVisionError(err: unknown): boolean {
+  const msg = (err instanceof Error ? err.message : String(err)).toLowerCase()
+  return msg.includes('does not support image') || msg.includes('image input')
+}
+
+function noVisionError(model: string): Error {
+  return new Error(
+    `"${model}" can't read images — it has no vision support. Switch to a ` +
+    `vision-capable model (e.g. llava, llama3.2-vision, qwen2-vl) with /models, ` +
+    `then resend. Pull one with: ollama pull llava`,
+  )
+}
+
 export async function listModels(entry: ProviderEntry): Promise<string[]> {
   try {
     const { models } = await makeClient(entry).list()
@@ -133,6 +148,7 @@ export async function* chat(
     }
   } catch (err) {
     if (signal?.aborted) return
+    if (isNoVisionError(err)) throw noVisionError(model)
     if (isConnectionError(err)) {
       throw new Error(NOT_RUNNING)
     }
@@ -158,6 +174,7 @@ export async function* chat(
     }
   } catch (err) {
     if (opts?.signal?.aborted) return
+    if (isNoVisionError(err)) throw noVisionError(model)
     if (isConnectionError(err)) {
       throw new Error(NOT_RUNNING)
     }

--- a/src/session/store.ts
+++ b/src/session/store.ts
@@ -100,7 +100,10 @@ export function persistSession(id: string, messages: MiiMessage[], title?: strin
 
   const lines: string[] = [JSON.stringify({ type: 'meta', ...meta } satisfies MetaLine)]
   for (const message of messages) {
-    lines.push(JSON.stringify({ type: 'message', message } satisfies MessageLine))
+    // Drop attached image base64 before writing — it can be megabytes per turn
+    // and bloats the JSONL. Vision is a per-turn input, not durable context.
+    const { images: _img, ...rest } = message
+    lines.push(JSON.stringify({ type: 'message', message: rest } satisfies MessageLine))
   }
   writeFileSync(sessionPath(id), lines.join('\n') + '\n', 'utf-8')
 }

--- a/src/ui/clipboard.ts
+++ b/src/ui/clipboard.ts
@@ -1,0 +1,104 @@
+/**
+ * Read an image off the OS clipboard, returned as base64 (no data: prefix).
+ *
+ * The terminal never hands binary clipboard data to stdin — Cmd+V only pastes
+ * clipboard *text*. To attach a copied screenshot we shell out to a per-platform
+ * clipboard reader. Returns null when there is no image on the clipboard (or no
+ * reader is available), so the caller can show a notice instead of erroring.
+ */
+import { execFileSync } from 'child_process'
+import { existsSync, readFileSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+function safeRm(p: string): void {
+  try { rmSync(p, { force: true }) } catch { /* ignore */ }
+}
+
+/** Read the temp PNG as base64, then delete it. */
+function consume(p: string): string | null {
+  try {
+    const b64 = readFileSync(p).toString('base64')
+    return b64.length > 0 ? b64 : null
+  } catch {
+    return null
+  } finally {
+    safeRm(p)
+  }
+}
+
+function readMac(out: string): string | null {
+  // pngpaste is fast and clean, but optional (brew install pngpaste).
+  try {
+    execFileSync('pngpaste', [out], { stdio: 'ignore' })
+    if (existsSync(out)) return consume(out)
+  } catch { /* pngpaste missing or clipboard has no image */ }
+
+  // Fallback: AppleScript coerces the clipboard to PNG and writes it to `out`.
+  // The coercion throws when there is no image → caught, returns "NOIMG".
+  const png = '«class PNGf»' // «class PNGf»
+  const script = [
+    'try',
+    `set f to open for access (POSIX file "${out}") with write permission`,
+    `set theData to (the clipboard as ${png})`,
+    'write theData to f',
+    'close access f',
+    'on error',
+    'try',
+    'close access f',
+    'end try',
+    'return "NOIMG"',
+    'end try',
+  ]
+  try {
+    const res = execFileSync('osascript', script.flatMap((s) => ['-e', s]), { encoding: 'utf8' })
+    if (res.includes('NOIMG')) { safeRm(out); return null }
+    if (existsSync(out)) return consume(out)
+  } catch { /* osascript failed */ }
+  safeRm(out)
+  return null
+}
+
+function readLinux(out: string): string | null {
+  // Wayland first, then X11. Both write the PNG to stdout; redirect to file.
+  for (const [cmd, args] of [
+    ['wl-paste', ['--type', 'image/png']],
+    ['xclip', ['-selection', 'clipboard', '-t', 'image/png', '-o']],
+  ] as const) {
+    try {
+      const buf = execFileSync(cmd, args, { maxBuffer: 64 * 1024 * 1024 })
+      if (buf.length > 0) return buf.toString('base64')
+    } catch { /* tool missing or no image */ }
+  }
+  return null
+}
+
+function readWindows(out: string): string | null {
+  // PowerShell pulls the clipboard image via WinForms and saves it as PNG.
+  // GetImage() returns $null when the clipboard holds no image → "NOIMG".
+  const ps = [
+    'Add-Type -AssemblyName System.Windows.Forms,System.Drawing;',
+    '$img = [System.Windows.Forms.Clipboard]::GetImage();',
+    // Single-quoted PS string → backslashes are literal, no escaping needed.
+    `if ($img -ne $null) { $img.Save('${out}', [System.Drawing.Imaging.ImageFormat]::Png); 'OK' } else { 'NOIMG' }`,
+  ].join(' ')
+  try {
+    const res = execFileSync(
+      'powershell',
+      ['-NoProfile', '-NonInteractive', '-STA', '-Command', ps],
+      { encoding: 'utf8' },
+    )
+    if (res.includes('NOIMG')) { safeRm(out); return null }
+    if (existsSync(out)) return consume(out)
+  } catch { /* powershell missing or no image */ }
+  safeRm(out)
+  return null
+}
+
+export function readClipboardImage(): string | null {
+  const out = join(tmpdir(), `miii-clip-${Date.now()}-${Math.random().toString(36).slice(2)}.png`)
+  if (process.platform === 'darwin') return readMac(out)
+  if (process.platform === 'linux') return readLinux(out)
+  if (process.platform === 'win32') return readWindows(out)
+  return null
+}

--- a/src/ui/constants.ts
+++ b/src/ui/constants.ts
@@ -6,6 +6,7 @@ export const EMPTY_STATE_HINTS: string[] = [
   '• /models — switch model or effort',
   '• /new — start a new chat',
   '• /sessions — view saved chats',
+  '• ctrl+v — paste an image (needs a vision model)',
   '• ctrl+t — toggle thinking',
 ]
 

--- a/src/ui/hooks/useAgentRunner.ts
+++ b/src/ui/hooks/useAgentRunner.ts
@@ -51,7 +51,7 @@ export function useAgentRunner(model: string | undefined, activeCtx: number | nu
     req.resolve(answers[cursor])
   }
 
-  async function sendMessage(text: string) {
+  async function sendMessage(text: string, images?: string[]) {
     if (busyRef.current || !model) return
     busyRef.current = true
     setBusy(true)
@@ -118,6 +118,7 @@ export function useAgentRunner(model: string | undefined, activeCtx: number | nu
         cwd: process.cwd(),
         history: agentHistory,
         userText: text,
+        images,
         permissions: { ask: askPermission },
         signal: controller.signal,
         num_ctx: activeCtx ?? undefined,

--- a/src/ui/hooks/useKeyboard.ts
+++ b/src/ui/hooks/useKeyboard.ts
@@ -4,7 +4,11 @@
  * Centralises key routing so App.tsx stays declarative.
  * Depends on refs/setters passed in from App state.
  */
+import { existsSync, readFileSync } from 'fs'
+import { basename, join } from 'path'
+import { homedir } from 'os'
 import { useInput, useStdout } from 'ink'
+import { readClipboardImage } from '../clipboard.js'
 import { setModel, setEffort, type NamedProvider, type Provider, type Effort } from '../../config.js'
 import { filteredCommands } from '../CommandPalette.js'
 import { parseMention, searchFiles } from '../FilePicker.js'
@@ -35,9 +39,47 @@ const PASTE_CHIP_CHARS = 200
 const pasteStore = new Map<string, string>()
 let pasteCounter = 0
 
+// Maps an image chip placeholder (e.g. "[Image #1 · shot.png]") to the base64
+// bytes of a pasted image file path. Collected at submit and sent as the user
+// message's `images[]` for vision models. Wiped alongside pasteStore.
+const imageStore = new Map<string, string>()
+let imageCounter = 0
+
+// File-path paste → image: a pasted absolute path ending in one of these is read
+// off disk, base64-encoded, and turned into an image chip.
+const IMAGE_EXT_RE = /\.(png|jpe?g|webp|gif|bmp)$/i
+
 function clearPasteStore() {
   pasteStore.clear()
   pasteCounter = 0
+  imageStore.clear()
+  imageCounter = 0
+}
+
+/**
+ * If `cleaned` is a single existing image file path, read it, base64-encode it,
+ * stash it in imageStore under a fresh chip, and return that chip. Otherwise
+ * return null so the caller falls back to normal paste handling.
+ *
+ * Handles surrounding quotes, macOS drag-drop backslash-escaped spaces, and ~.
+ */
+function tryImagePaste(cleaned: string): string | null {
+  let p = cleaned.trim()
+  if ((p.startsWith('"') && p.endsWith('"')) || (p.startsWith("'") && p.endsWith("'"))) {
+    p = p.slice(1, -1)
+  }
+  p = p.replace(/\\ /g, ' ')
+  if (p.includes('\n') || !IMAGE_EXT_RE.test(p)) return null
+  if (p.startsWith('~/')) p = join(homedir(), p.slice(2))
+  if (!existsSync(p)) return null
+  try {
+    const b64 = readFileSync(p).toString('base64')
+    const chip = `[Image #${++imageCounter} · ${basename(p)}]`
+    imageStore.set(chip, b64)
+    return chip
+  } catch {
+    return null
+  }
 }
 
 // Submitted-input history for up/down recall (Claude Code-style). Module-level
@@ -85,6 +127,9 @@ function sanitizePaste(chunk: string): string {
   // Gate the paste machinery on length>1 — typing is the hot path.
   if (chunk.length <= 1) return chunk
   const cleaned = stripControls(chunk).replace(/\r/g, '')
+  // A pasted image file path becomes an image chip (sent as images[] at submit).
+  const imageChip = tryImagePaste(cleaned)
+  if (imageChip) return imageChip
   const lines = cleaned.split('\n').length
   if (lines > PASTE_CHIP_LINES || cleaned.length > PASTE_CHIP_CHARS) {
     const chip = `[Pasted #${++pasteCounter} · ${lines} line${lines === 1 ? '' : 's'}]`
@@ -318,6 +363,19 @@ export function useKeyboard(opts: KeyboardOptions) {
     if (state === 'ready') {
       if (busyRef.current) return
 
+      // Ctrl+V — paste an image off the OS clipboard (Cmd+V only pastes text, so
+      // a copied screenshot needs an explicit reader). Inserts an image chip.
+      if (key.ctrl && char === 'v') {
+        const b64 = readClipboardImage()
+        if (!b64) { setNotice('no image in clipboard'); return }
+        const chip = `[Image #${++imageCounter} · clipboard]`
+        imageStore.set(chip, b64)
+        historyIndex = -1
+        setInput((s) => s.slice(0, caret) + chip + s.slice(caret))
+        setCaret((i) => i + chip.length)
+        return
+      }
+
       const paletteOpen = input.startsWith('/')
       const matches = paletteOpen ? filteredCommands(input) : []
       const mention = !paletteOpen ? parseMention(input) : null
@@ -418,11 +476,21 @@ export function useKeyboard(opts: KeyboardOptions) {
           }
         } else if (trimmed) {
           setNotice(null)
+          // Pull any image chips out of the text, gathering their base64 bytes
+          // to send as the message's images[]. The chip text itself is removed.
+          const images: string[] = []
+          let textPart = trimmed
+          for (const [chip, b64] of imageStore) {
+            if (textPart.includes(chip)) {
+              images.push(b64)
+              textPart = textPart.split(chip).join('').trim()
+            }
+          }
           // Expand any paste chips back into their real text before sending.
           // The session title is generated after the first assistant reply
           // (see the auto-save effect in App.tsx), not from this raw message.
-          const message = expandPastes(trimmed)
-          sendMessage(message)
+          const message = expandPastes(textPart) || 'Describe the attached image.'
+          sendMessage(message, images.length ? images : undefined)
         }
         clearPasteStore()
         setInput(() => '')
@@ -449,8 +517,11 @@ export function useKeyboard(opts: KeyboardOptions) {
         for (const chip of pasteStore.keys()) {
           if (before.endsWith(chip) && chip.length > match.length) match = chip
         }
+        for (const chip of imageStore.keys()) {
+          if (before.endsWith(chip) && chip.length > match.length) match = chip
+        }
         const cut = match ? match.length : 1
-        if (match) pasteStore.delete(match)
+        if (match) { pasteStore.delete(match); imageStore.delete(match) }
         setInput((s) => s.slice(0, caret - cut) + s.slice(caret))
         setCaret((i) => Math.max(0, i - cut))
       } else if (char && !key.ctrl && !key.meta && !key.tab) {


### PR DESCRIPTION
Attach images to a message two ways:
- Ctrl+V reads an image off the OS clipboard (macOS/Linux/Windows)
- pasting an image file path reads it off disk

Images ride as the user message's images[] for vision-capable models. Non-vision models get a clear, actionable error instead of Ollama's cryptic "does not support image input". Image base64 is stripped before session persistence to avoid bloating JSONL.