### PR TITLE
feat: background auto-update and leaked tool-call recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,11 @@ Your code never leaves your disk. There's nothing to log in to. Pull a model, ty
 
 ```bash
 ollama pull qwen2.5-coder:14b   # any coding model works
-npm install -g miii-agent
+curl -fsSL https://raw.githubusercontent.com/maruakshay/miii-cli/main/install.sh | sh
 miii
 ```
+
+Prefer npm? `npm install -g miii-agent`.
 
 Then just talk to it:
 
@@ -43,6 +45,19 @@ Then just talk to it:
 ```
 
 > **Needs:** Node ≥ 18 and [Ollama](https://ollama.com/download) running locally.
+
+## Staying up to date
+
+miii checks npm on launch and, when a newer release exists, pulls it in the
+background — it applies the next time you start. Manual options:
+
+```bash
+miii update     # update now
+miii --version  # what you're running
+```
+
+Opt out of background updates by adding `"autoUpdate": false` to `~/.miii/config.json`,
+or re-run the install script (`curl … | sh`) any time to update by hand.
 
 ## Why local-first?
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env sh
+# miii installer / updater
+#
+#   curl -fsSL https://raw.githubusercontent.com/maruakshay/miii-cli/main/install.sh | sh
+#
+# Re-run any time to update to the latest release.
+set -eu
+
+PKG="miii-agent"
+GREEN="$(printf '\033[32m')"; YELLOW="$(printf '\033[33m')"; RED="$(printf '\033[31m')"; DIM="$(printf '\033[2m')"; RESET="$(printf '\033[0m')"
+
+info()  { printf '%s\n' "${GREEN}==>${RESET} $*"; }
+warn()  { printf '%s\n' "${YELLOW}!!${RESET} $*" >&2; }
+die()   { printf '%s\n' "${RED}xx${RESET} $*" >&2; exit 1; }
+
+# --- Node ---
+command -v node >/dev/null 2>&1 || die "Node.js not found. Install Node >= 18 from https://nodejs.org"
+NODE_MAJOR="$(node -p 'process.versions.node.split(".")[0]' 2>/dev/null || echo 0)"
+[ "$NODE_MAJOR" -ge 18 ] || die "Node >= 18 required (found $(node -v)). Upgrade from https://nodejs.org"
+
+# --- npm ---
+command -v npm >/dev/null 2>&1 || die "npm not found. It ships with Node.js — reinstall from https://nodejs.org"
+
+# Detect install vs update for nicer messaging.
+if npm ls -g "$PKG" >/dev/null 2>&1; then
+  info "Updating ${PKG} to the latest release…"
+else
+  info "Installing ${PKG}…"
+fi
+
+# Global installs may need sudo when the npm prefix isn't user-writable.
+if npm i -g "${PKG}@latest" 2>/dev/null; then
+  :
+elif command -v sudo >/dev/null 2>&1; then
+  warn "Global install needs elevated permissions — retrying with sudo."
+  sudo npm i -g "${PKG}@latest"
+else
+  die "Install failed and sudo is unavailable. Fix your npm prefix or run as a user that can write to it."
+fi
+
+VERSION="$(miii --version 2>/dev/null || npm view "$PKG" version 2>/dev/null || echo '')"
+info "Done.${VERSION:+ ${DIM}($PKG $VERSION)${RESET}}"
+
+# --- Ollama hint ---
+if ! command -v ollama >/dev/null 2>&1; then
+  warn "Ollama not detected. miii needs a local model server."
+  printf '%s\n' "${DIM}   Install: https://ollama.com/download${RESET}"
+  printf '%s\n' "${DIM}   Then:    ollama pull qwen2.5-coder:14b${RESET}"
+fi
+
+printf '\n%s\n' "Run ${GREEN}miii${RESET} to start."

--- a/src/agent/adapter.test.ts
+++ b/src/agent/adapter.test.ts
@@ -3,6 +3,7 @@ import {
   parseTextToolCalls,
   blocksFromOllama,
   toOllamaMessages,
+  looksLikeLeakedToolCall,
 } from './adapter.js'
 import type { MiiMessage, ToolUse } from './types.js'
 
@@ -48,6 +49,67 @@ describe('parseTextToolCalls', () => {
 
   it('returns nothing for empty input', () => {
     expect(parseTextToolCalls('', KNOWN).calls).toHaveLength(0)
+  })
+
+  it('parses the call:NAME{...} delimiter-wrapped syntax', () => {
+    const src = 'call:run_bash{command:<|"|>ls -la<|"|>}'
+    const { calls, cleanedText } = parseTextToolCalls(src, KNOWN)
+    expect(calls).toHaveLength(1)
+    expect(calls[0].function).toEqual({ name: 'run_bash', arguments: { command: 'ls -la' } })
+    expect(cleanedText).toBe('')
+  })
+
+  it('keeps delimited values that span newlines and braces intact', () => {
+    const body = 'function f() {\n  return { a: 1 };\n}'
+    const src = `call:edit_file{path:<|"|>a.js<|"|>,content:<|"|>${body}<|"|>}`
+    const { calls } = parseTextToolCalls(src, KNOWN)
+    expect(calls).toHaveLength(1)
+    expect(calls[0].function.name).toBe('edit_file')
+    expect(calls[0].function.arguments).toEqual({ path: 'a.js', content: body })
+  })
+
+  it('ignores call:NAME for an unknown tool', () => {
+    const { calls, cleanedText } = parseTextToolCalls('call:frobnicate{x:<|"|>1<|"|>}', KNOWN)
+    expect(calls).toHaveLength(0)
+    expect(cleanedText).toContain('frobnicate')
+  })
+
+  it('parses bare (undelimited) values in call syntax', () => {
+    const { calls } = parseTextToolCalls('call:read_file{path:"a.ts"}', KNOWN)
+    expect(calls[0].function.arguments).toEqual({ path: 'a.ts' })
+  })
+
+  it('does not extract a call embedded in an unknown call\'s value', () => {
+    const src = 'call:frobnicate{x:<|"|>call:read_file{path:secret.ts}<|"|>}'
+    const { calls } = parseTextToolCalls(src, KNOWN)
+    expect(calls).toHaveLength(0)
+  })
+})
+
+describe('looksLikeLeakedToolCall', () => {
+  it('flags the <|"|> delimiter sentinel', () => {
+    expect(looksLikeLeakedToolCall('content:<|"|>x<|"|>', KNOWN)).toBe(true)
+  })
+  it('flags call:NAME{ syntax', () => {
+    expect(looksLikeLeakedToolCall('call:run_bash{cmd:1}', KNOWN)).toBe(true)
+  })
+  it('flags a <tool_call tag', () => {
+    expect(looksLikeLeakedToolCall('<tool_call>{}', KNOWN)).toBe(true)
+  })
+  it('flags a JSON object naming a known tool with arguments', () => {
+    expect(looksLikeLeakedToolCall('{"name":"read_file","arguments":{}}', KNOWN)).toBe(true)
+  })
+  it('does NOT flag prose that mentions a tool', () => {
+    expect(looksLikeLeakedToolCall('I read the file with read_file earlier.', KNOWN)).toBe(false)
+  })
+  it('does NOT flag a JSON object naming an unknown tool', () => {
+    expect(looksLikeLeakedToolCall('{"name":"frobnicate","arguments":{}}', KNOWN)).toBe(false)
+  })
+  it('does NOT flag prose "call:" for an unknown name', () => {
+    expect(looksLikeLeakedToolCall("I'll call: someone {later} about it.", KNOWN)).toBe(false)
+  })
+  it('does NOT flag empty text', () => {
+    expect(looksLikeLeakedToolCall('', KNOWN)).toBe(false)
   })
 })
 

--- a/src/agent/adapter.ts
+++ b/src/agent/adapter.ts
@@ -63,6 +63,7 @@ type RawToolCall = { function: { name: string; arguments: Record<string, unknown
  *   {"name": "X", "parameters": {...}}
  *   <tool_call>{...}</tool_call>      (qwen)
  *   ```json {...} ```                  (fenced)
+ *   call:X{key:<|"|>value<|"|>, ...}  (delimiter-wrapped, non-JSON)
  */
 export function parseTextToolCalls(
   text: string,
@@ -71,6 +72,15 @@ export function parseTextToolCalls(
   if (!text) return { calls: [], cleanedText: text }
   const calls: RawToolCall[] = []
   let cleaned = text
+
+  // Custom `call:NAME{...}` syntax that some local models emit instead of JSON.
+  // Handled first because its body is not valid JSON and would otherwise leak
+  // into the rendered text verbatim.
+  const callSyntax = parseCallSyntax(cleaned, knownToolNames)
+  if (callSyntax.calls.length > 0) {
+    calls.push(...callSyntax.calls)
+    cleaned = callSyntax.cleanedText
+  }
 
   const tagRe = /<\|?tool_call\|?>\s*([\s\S]*?)\s*<\|?\/?tool_call\|?>/g
   cleaned = cleaned.replace(tagRe, (_m, body: string) => {
@@ -114,6 +124,100 @@ function tryParse(raw: string, knownToolNames: string[]): RawToolCall | null {
   }
 }
 
+const VAL_DELIM = '<|"|>'
+
+/**
+ * Parse the `call:NAME{ key:<|"|>value<|"|>, ... }` syntax. Values are wrapped
+ * in the VAL_DELIM sentinel so they may freely contain newlines, braces, quotes
+ * and commas — the delimiter, not brace/comma balancing, marks the boundaries.
+ * Bare (undelimited) values are tolerated as a fallback: they are read up to the
+ * next top-level comma or closing brace and JSON-parsed when possible.
+ */
+function parseCallSyntax(
+  text: string,
+  knownToolNames: string[],
+): { calls: RawToolCall[]; cleanedText: string } {
+  const calls: RawToolCall[] = []
+  const headRe = /call:\s*([a-zA-Z_]\w*)\s*\{/g
+  let m: RegExpExecArray | null
+  let cleaned = ''
+  let lastEnd = 0
+
+  while ((m = headRe.exec(text)) !== null) {
+    const name = m[1]
+    const body = parseCallBody(text, m.index + m[0].length)
+    if (!body) continue
+    // Skip past the whole body before the next exec, even for unknown tools, so
+    // a `call:...{...}` embedded in an unknown call's value isn't rescanned and
+    // mistaken for a real call.
+    headRe.lastIndex = body.end
+    if (!knownToolNames.includes(name)) continue
+    calls.push({ function: { name, arguments: body.args } })
+    cleaned += text.slice(lastEnd, m.index)
+    lastEnd = body.end
+  }
+  cleaned += text.slice(lastEnd)
+  return { calls, cleanedText: cleaned.trim() }
+}
+
+function parseCallBody(
+  text: string,
+  start: number,
+): { args: Record<string, unknown>; end: number } | null {
+  const args: Record<string, unknown> = {}
+  let i = start
+  const isWs = (c: string) => c === ' ' || c === '\t' || c === '\n' || c === '\r'
+
+  while (i < text.length) {
+    while (i < text.length && (isWs(text[i]) || text[i] === ',')) i++
+    if (i >= text.length) return null
+    if (text[i] === '}') return { args, end: i + 1 }
+
+    // key
+    const keyStart = i
+    while (i < text.length && text[i] !== ':' && text[i] !== '}') i++
+    if (i >= text.length || text[i] !== ':') return null
+    const key = text.slice(keyStart, i).trim().replace(/^["']|["']$/g, '')
+    i++ // skip ':'
+    while (i < text.length && isWs(text[i])) i++
+
+    // value
+    if (text.startsWith(VAL_DELIM, i)) {
+      const vStart = i + VAL_DELIM.length
+      const vEnd = text.indexOf(VAL_DELIM, vStart)
+      if (vEnd === -1) return null
+      args[key] = text.slice(vStart, vEnd)
+      i = vEnd + VAL_DELIM.length
+    } else {
+      const vStart = i
+      let depth = 0
+      let inStr: string | null = null
+      let esc = false
+      while (i < text.length) {
+        const ch = text[i]
+        if (inStr) {
+          if (esc) esc = false
+          else if (ch === '\\') esc = true
+          else if (ch === inStr) inStr = null
+        } else if (ch === '"' || ch === "'") inStr = ch
+        else if (ch === '{' || ch === '[') depth++
+        else if (ch === '}' || ch === ']') {
+          if (depth === 0) break
+          depth--
+        } else if (ch === ',' && depth === 0) break
+        i++
+      }
+      const rawVal = text.slice(vStart, i).trim()
+      try {
+        args[key] = JSON.parse(rawVal)
+      } catch {
+        args[key] = rawVal.replace(/^["']|["']$/g, '')
+      }
+    }
+  }
+  return null // never hit closing brace
+}
+
 function extractFirstJsonObject(s: string): { json: string; start: number; end: number } | null {
   const start = s.indexOf('{')
   if (start === -1) return null
@@ -136,6 +240,31 @@ function extractFirstJsonObject(s: string): { json: string; start: number; end: 
     }
   }
   return null
+}
+
+/**
+ * Heuristic: does this leftover text look like a tool call the model tried to
+ * emit as prose but that we failed to parse into a structured call? Used by the
+ * agent loop to nudge the model to re-emit via the native interface instead of
+ * silently ending the turn with the raw syntax leaked to the user.
+ *
+ * Conservative on purpose — only fires on strong markers, never on a tool name
+ * merely mentioned in prose, so it cannot block a legitimate final answer.
+ */
+export function looksLikeLeakedToolCall(text: string, knownToolNames: string[]): boolean {
+  if (!text) return false
+  if (text.includes(VAL_DELIM)) return true
+  if (/<\|?tool_call/i.test(text)) return true
+  // `call:NAME{` — but only when NAME is an actual tool, so prose like
+  // "I'll call: someone {" can't trip the nudge.
+  const callMatch = text.match(/\bcall:\s*(\w+)\s*\{/)
+  if (callMatch && knownToolNames.includes(callMatch[1])) return true
+  // JSON object literal that names a known tool with an args/params field.
+  if (/"name"\s*:\s*"([^"]+)"/.test(text) && /"(arguments|parameters|input)"\s*:/.test(text)) {
+    const name = text.match(/"name"\s*:\s*"([^"]+)"/)?.[1]
+    if (name && knownToolNames.includes(name)) return true
+  }
+  return false
 }
 
 export function blocksFromOllama(

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -11,6 +11,7 @@ import { HookBus } from '../hooks/bus.js'
 import {
   toOllamaMessages,
   blocksFromOllama,
+  looksLikeLeakedToolCall,
 } from './adapter.js'
 import type {
   MiiMessage,
@@ -23,6 +24,9 @@ import type {
 const MAX_TURNS = 25
 const REPEAT_TAIL = 120
 const REPEAT_KILL = 4
+// Max times to ask the model to re-emit a leaked text tool call via the native
+// interface before giving up and ending the turn.
+const MAX_LEAK_NUDGES = 2
 
 /**
  * Harness-enforced read-before-write. The system prompt asks the model to read
@@ -156,6 +160,10 @@ export async function* runAgent(opts: RunAgentOpts): AsyncGenerator<AgentEvent, 
   let evalTokens = 0
   let lastAssistantSig = ''
   let repeatCount = 0
+  // How many times we've asked the model to re-emit a leaked text tool call via
+  // the native interface this run. Bounded so a model that can't comply ends the
+  // turn instead of looping forever.
+  let leakNudges = 0
   // Canonical paths the model has read (or written) this run — gates edit/write.
   const seenPaths = new Set<string>()
 
@@ -262,6 +270,27 @@ export async function* runAgent(opts: RunAgentOpts): AsyncGenerator<AgentEvent, 
     }
 
     if (tool_uses.length === 0) {
+      // The model produced no structured tool call, but its text looks like it
+      // tried to call a tool in some prose syntax we couldn't parse (so it leaked
+      // verbatim to the user and no file was actually written). Nudge it to
+      // re-emit via the native function-calling interface rather than ending the
+      // turn on a silent no-op. Bounded so a model that can't comply still exits.
+      const assistantText = blocks
+        .filter((b): b is { type: 'text'; text: string } => b.type === 'text')
+        .map((b) => b.text)
+        .join('')
+      if (leakNudges < MAX_LEAK_NUDGES && looksLikeLeakedToolCall(assistantText, toolNames)) {
+        leakNudges++
+        history.push({
+          role: 'user',
+          content:
+            'That tool call was written as plain text, so it did not run and nothing happened. ' +
+            'Re-issue it using the function-calling interface only — do not print the call as ' +
+            'text, JSON, or any custom syntax. If you did not mean to call a tool, answer in prose.',
+        })
+        yield { type: 'turn-end', stop_reason: 'tool_use' }
+        continue
+      }
       yield { type: 'turn-end', stop_reason: 'end_turn' }
       break
     }

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -21,7 +21,12 @@ for (let i = 0; i < args.length; i++) {
   }
 }
 
-if (cmd === 'update' || cmd === '--update' || cmd === '-u') {
+if (cmd === 'version' || cmd === '--version' || cmd === '-v') {
+  const { createRequire } = await import('module')
+  const pkg = createRequire(import.meta.url)('../package.json') as { version: string }
+  console.log(pkg.version)
+  process.exit(0)
+} else if (cmd === 'update' || cmd === '--update' || cmd === '-u') {
   const { spawnSync } = await import('child_process')
   console.log('Updating miii-agent…')
   const r = spawnSync('npm', ['i', '-g', 'miii-agent@latest'], { stdio: 'inherit', shell: process.platform === 'win32' })

--- a/src/config.ts
+++ b/src/config.ts
@@ -25,6 +25,9 @@ export interface Config {
   // Last-known context window per model. Seeds the header on first render so it
   // shows a real value instead of "— ctx" while the live `show` request loads.
   modelContexts?: Record<string, number>
+  // When true (default), a detected newer release is installed in the background
+  // on launch. Set false to keep the manual `miii update` flow only.
+  autoUpdate?: boolean
   // legacy fields — migrated into `providers` on load
   ollamaHost?: string
   lmstudioHost?: string
@@ -70,7 +73,17 @@ function migrate(raw: Config): Config {
     effort: raw.effort,
     providers,
     modelContexts: raw.modelContexts,
+    autoUpdate: raw.autoUpdate,
   }
+}
+
+// Background auto-update is on unless the user explicitly disabled it.
+export function autoUpdateEnabled(cfg: Config = loadConfig()): boolean {
+  return cfg.autoUpdate !== false
+}
+
+export function setAutoUpdate(enabled: boolean): void {
+  saveConfig({ ...readRawConfig(), autoUpdate: enabled })
 }
 
 // Exactly what's on disk — no defaults, no env, no migration. Used by setters so

--- a/src/prompt/system.ts
+++ b/src/prompt/system.ts
@@ -88,7 +88,8 @@ Ask in a numbered list. One round of questions per turn. Then wait.
 
 # Tool calls
 - When you need a tool, emit the tool call directly. No preamble, no narration, no "I will use X".
-- Never describe a tool call instead of emitting it. If you cannot emit the call, answer in plain text.
+- Use the native function-calling interface as the ONLY channel for tool calls. Never print a tool call as text — not as JSON, not as a fenced code block, not as \`call:name{...}\`, not in any custom or tagged syntax. Text-form calls do NOT execute; they leak to the user and nothing happens.
+- If you cannot emit a real function call, do not fake one in prose — answer in plain text instead.
 - After a tool result, move directly to the next tool call or the final answer. Do not restate what the previous tool did.
 
 # Tools

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -9,8 +9,8 @@ import { Box, Text, useApp } from 'ink'
 import { homedir } from 'os'
 import { sep } from 'path'
 import { listModels, modelContext, isAvailable, NOT_AVAILABLE } from '../llm/client.js'
-import { loadConfig, setProvider, setModelContexts, providerEntries, resolveProvider, type Effort, type Provider } from '../config.js'
-import { WelcomeBlock } from './WelcomeBlock.js'
+import { loadConfig, setProvider, setModelContexts, providerEntries, resolveProvider, autoUpdateEnabled, type Effort, type Provider } from '../config.js'
+import { WelcomeBlock, updateBannerText, type UpdateStatus } from './WelcomeBlock.js'
 import { InputBar } from './InputBar.js'
 import { ModelsView } from './ModelsView.js'
 import { ProviderPicker } from './ProviderPicker.js'
@@ -21,7 +21,7 @@ import { FilePicker, parseMention, searchFiles } from './FilePicker.js'
 import { ChatView } from './ChatView.js'
 import { useAgentRunner } from './hooks/useAgentRunner.js'
 import { useKeyboard } from './hooks/useKeyboard.js'
-import { checkForUpdate } from '../updateCheck.js'
+import { checkForUpdate, autoUpdate } from '../updateCheck.js'
 
 type AppState = 'loading' | 'select-model' | 'ready' | 'models' | 'providers' | 'sessions'
 
@@ -42,6 +42,7 @@ export function App() {
   const [cursor, setCursor] = useState(0)
   const [pickerQuery, setPickerQuery] = useState('')
   const [updateAvailable, setUpdateAvailable] = useState<string | null>(null)
+  const [updateStatus, setUpdateStatus] = useState<UpdateStatus>('idle')
   const [providerDown, setProviderDown] = useState(false)
 
   // --- sessions ---
@@ -60,7 +61,17 @@ export function App() {
   const agent = useAgentRunner(cfg.model, activeCtx)
 
   useEffect(() => {
-    checkForUpdate().then((v) => { if (v) setUpdateAvailable(v) })
+    checkForUpdate().then((v) => {
+      if (!v) return
+      setUpdateAvailable(v)
+      // Pull the new release in the background; it applies on next launch. Track
+      // the real outcome: downloading while it runs, then installed or failed.
+      // Stays 'idle' (manual banner) on the rate-limit cooldown or a failed spawn.
+      if (autoUpdateEnabled()) {
+        const started = autoUpdate((ok) => setUpdateStatus(ok ? 'installed' : 'failed'))
+        if (started) setUpdateStatus('downloading')
+      }
+    })
   }, [])
 
   // Tracks sessions whose LLM title has been generated, so we summarise once.
@@ -200,7 +211,7 @@ export function App() {
           banner moves into ChatView's <Static> log (Ink prints Static above the
           live frame, so a dynamic banner here would sink below the scrollback). */}
       {state !== 'ready' && (
-        <WelcomeBlock model={cfg.model} activeCtx={activeCtx} effort={effort} cwd={cwd} error={agent.error} updateAvailable={updateAvailable} />
+        <WelcomeBlock model={cfg.model} activeCtx={activeCtx} effort={effort} cwd={cwd} error={agent.error} updateAvailable={updateAvailable} updateStatus={updateStatus} />
       )}
 
       {state === 'loading' && !agent.error && (
@@ -291,6 +302,13 @@ export function App() {
                 {providerDown
                   ? 'provider unavailable — /provider to switch · /models to pick a model'
                   : 'type / to see commands'}
+              </Text>
+            </Box>
+          )}
+          {updateAvailable && (
+            <Box marginLeft={2} marginBottom={1}>
+              <Text color={updateStatus === 'failed' ? 'red' : updateStatus === 'installed' ? 'green' : 'yellow'}>
+                {updateBannerText(updateAvailable, updateStatus)}
               </Text>
             </Box>
           )}

--- a/src/ui/WelcomeBlock.tsx
+++ b/src/ui/WelcomeBlock.tsx
@@ -1,6 +1,28 @@
 import { Box, Text } from 'ink'
 import type { Effort } from '../config.js'
 
+// Lifecycle of the background self-update for the launch banner.
+//   idle        — a newer release exists; auto-update off, on cooldown, or failed to start
+//   downloading — install kicked off in the background
+//   installed   — background install finished; applies on next launch
+//   failed      — background install exited non-zero
+export type UpdateStatus = 'idle' | 'downloading' | 'installed' | 'failed'
+
+// Single source of truth for the update banner copy, shared by the welcome
+// header and the in-chat banner so they never drift.
+export function updateBannerText(version: string, status: UpdateStatus): string {
+  switch (status) {
+    case 'downloading':
+      return `↑ v${version} downloading in the background — restart miii to apply`
+    case 'installed':
+      return `✓ v${version} installed — restart miii to apply`
+    case 'failed':
+      return `↑ v${version} update failed — run \`miii update\` manually`
+    default:
+      return `↑ v${version} available — run \`miii update\` to upgrade`
+  }
+}
+
 interface Props {
   model: string | undefined
   activeCtx: number | null
@@ -8,9 +30,10 @@ interface Props {
   cwd: string
   error?: string | null
   updateAvailable?: string | null
+  updateStatus?: UpdateStatus
 }
 
-export function WelcomeBlock({ model, activeCtx, effort, cwd, updateAvailable }: Props) {
+export function WelcomeBlock({ model, activeCtx, effort, cwd, updateAvailable, updateStatus = 'idle' }: Props) {
   const ctxLabel = activeCtx != null ? `${Math.round(activeCtx / 1024)}k ctx` : '— ctx'
   return (
     <Box flexDirection="column" marginBottom={1}>
@@ -32,7 +55,9 @@ export function WelcomeBlock({ model, activeCtx, effort, cwd, updateAvailable }:
         <Text dimColor>{cwd}</Text>
       </Box>
       {updateAvailable && (
-        <Text color="yellow">{`↑ update available: v${updateAvailable} — run: miii --update`}</Text>
+        <Text color={updateStatus === 'failed' ? 'red' : updateStatus === 'installed' ? 'green' : 'yellow'}>
+          {updateBannerText(updateAvailable, updateStatus)}
+        </Text>
       )}
     </Box>
   )

--- a/src/updateCheck.ts
+++ b/src/updateCheck.ts
@@ -1,7 +1,34 @@
 import { createRequire } from 'module'
+import { homedir } from 'os'
+import { join } from 'path'
+import { readFileSync, writeFileSync, mkdirSync } from 'fs'
 
 const require = createRequire(import.meta.url)
 const PKG_NAME = 'miii-agent'
+
+// Rate-limit window for background self-updates. A user who quits and relaunches
+// repeatedly while npm is still installing would otherwise spawn concurrent
+// global installs that fight over npm's lock.
+const UPDATE_ATTEMPT_PATH = join(homedir(), '.miii', '.last-update-attempt')
+const UPDATE_ATTEMPT_COOLDOWN_MS = 10 * 60 * 1000
+
+function recentlyAttemptedUpdate(): boolean {
+  try {
+    const last = Number(readFileSync(UPDATE_ATTEMPT_PATH, 'utf8').trim())
+    return Number.isFinite(last) && Date.now() - last < UPDATE_ATTEMPT_COOLDOWN_MS
+  } catch {
+    return false
+  }
+}
+
+function markUpdateAttempt(): void {
+  try {
+    mkdirSync(join(homedir(), '.miii'), { recursive: true })
+    writeFileSync(UPDATE_ATTEMPT_PATH, String(Date.now()))
+  } catch {
+    // ignore — worst case we lose the rate-limit guard
+  }
+}
 
 function currentVersion(): string {
   try {
@@ -18,6 +45,46 @@ function newerVersion(current: string, latest: string): boolean {
   if (la !== ca) return la > ca
   if (lb !== cb) return lb > cb
   return lc > cc
+}
+
+// Install the latest release detached in the background so it never blocks the
+// running session. The new version takes effect on the next launch. Best-effort:
+// a global install needing sudo, or no npm on PATH, just fails silently.
+//
+// Returns true only when an install was actually kicked off, so callers can show
+// a "downloading" state honestly. Returns false on the rate-limit cooldown or a
+// synchronous spawn failure — the manual `miii update` banner stands instead.
+//
+// `onDone` (optional) reports the eventual outcome while this process is still
+// alive: true if npm exited 0, false on non-zero exit or async spawn error. It
+// never fires when autoUpdate returns false. The child stays detached/unref'd so
+// the install survives the user quitting before it finishes.
+export function autoUpdate(onDone?: (ok: boolean) => void): boolean {
+  if (recentlyAttemptedUpdate()) return false
+  try {
+    markUpdateAttempt()
+    const { spawn } = require('child_process') as typeof import('child_process')
+    const child = spawn('npm', ['i', '-g', `${PKG_NAME}@latest`], {
+      detached: true,
+      stdio: 'ignore',
+      shell: process.platform === 'win32',
+    })
+    let settled = false
+    const settle = (ok: boolean) => {
+      if (settled) return
+      settled = true
+      onDone?.(ok)
+    }
+    // A failed spawn (e.g. npm not on PATH) emits 'error' asynchronously; an
+    // unhandled 'error' on a ChildProcess throws and would crash the TUI.
+    child.on('error', () => settle(false))
+    child.on('exit', (code) => settle(code === 0))
+    child.unref()
+    return true
+  } catch {
+    // ignore — fall back to the manual `miii update` banner
+    return false
+  }
 }
 
 export async function checkForUpdate(): Promise<string | null> {


### PR DESCRIPTION
Auto-update:
- check npm on launch; install newer release in the background, applied on next launch (opt out via autoUpdate:false in config)
- rate-limit attempts via ~/.miii/.last-update-attempt to avoid concurrent global installs on rapid restarts
- 4-state launch banner (downloading/installed/failed/idle) reporting the real npm outcome instead of an unconditional "downloading"
- add `miii --version`; unify update command to `miii update`; install.sh

Tool-call recovery:
- parse `call:NAME{...}` delimiter-wrapped syntax some local models emit
- nudge the model to re-emit via the native interface when a tool call leaks as text (bounded by MAX_LEAK_NUDGES); skip prose/unknown tools
- tighten system prompt to forbid text-form tool calls