### PR TITLE
feat: reflect session summary in terminal tab title

### DIFF
--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -36,5 +36,8 @@ if (cmd === 'version' || cmd === '--version' || cmd === '-v') {
   const { runEval } = await import('../eval/run.js')
   process.exit(await runEval(rest))
 } else {
+  // Restore the terminal tab title on any exit path (Ink's unmount cleanup
+  // can be skipped on a hard signal).
+  process.on('exit', () => { if (process.stdout.isTTY) process.stdout.write('\x1b]2;\x07') })
   render(createElement(App))
 }

--- a/src/llm/ollama.ts
+++ b/src/llm/ollama.ts
@@ -124,7 +124,7 @@ export async function* chat(
       model,
       messages: messages as Message[],
       stream: true,
-      think: true,
+      think: opts?.think ?? true,
       keep_alive: opts?.keep_alive ?? '10m',
       options,
     }

--- a/src/llm/types.ts
+++ b/src/llm/types.ts
@@ -45,4 +45,6 @@ export interface ChatOptions {
   num_ctx?: number
   keep_alive?: string
   signal?: AbortSignal
+  /** Enable model thinking/reasoning. Defaults to true for ollama. */
+  think?: boolean
 }

--- a/src/prompt/system.ts
+++ b/src/prompt/system.ts
@@ -91,6 +91,8 @@ Ask in a numbered list. One round of questions per turn. Then wait.
 - Use the native function-calling interface as the ONLY channel for tool calls. Never print a tool call as text — not as JSON, not as a fenced code block, not as \`call:name{...}\`, not in any custom or tagged syntax. Text-form calls do NOT execute; they leak to the user and nothing happens.
 - If you cannot emit a real function call, do not fake one in prose — answer in plain text instead.
 - After a tool result, move directly to the next tool call or the final answer. Do not restate what the previous tool did.
+- Every tool call MUST carry a complete, valid arguments object: all required fields present, correct types, valid JSON. Never emit a call with empty, partial, or placeholder arguments.
+- WRONG (leaks as text, nothing runs): writing \`call:some_tool{"foo":"bar"}\` or a fenced JSON block in your reply. RIGHT: emit it as a native function call with a full arguments object.
 
 # Tools
 You have access to the following tools. Call them via the function-calling interface.

--- a/src/session/store.ts
+++ b/src/session/store.ts
@@ -259,7 +259,9 @@ export async function summarizeConversation(
       model,
       [{ role: 'user', content: prompt }],
       undefined,
-      { temperature: 0.2, num_predict: 32 },
+      // Disable thinking + give content room: reasoning models otherwise burn
+      // the whole budget on hidden thinking and emit no title text.
+      { temperature: 0.2, num_predict: 64, think: false },
     )) {
       if (chunk.content) out += chunk.content
     }

--- a/src/tools/spill.ts
+++ b/src/tools/spill.ts
@@ -44,10 +44,9 @@ export function spillIfLarge(full: string, label = 'output', budget = INLINE_BUD
 
   const head = Math.floor(budget * HEAD_FRACTION)
   const tail = budget - head
-  const totalLines = full.split('\n').length
   const preview = full.slice(0, head) + '\n…\n' + full.slice(-tail)
   const notice = path
-    ? `[${label} truncated: ${totalLines} lines / ${full.length} bytes. Full output at ${path} — read it with read_file offset/limit to see the elided middle.]`
+    ? `[${label} truncated: ${full.length} bytes. Full output at ${path} — read it with read_file offset/limit to see the elided middle.]`
     : `[${label} truncated to ${budget} bytes; spill to disk failed, middle is lost.]`
   return `${preview}\n${notice}`
 }

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -17,6 +17,7 @@ import { ProviderPicker } from './ProviderPicker.js'
 import { SessionsView } from './SessionsView.js'
 import { CommandPalette } from './CommandPalette.js'
 import { persistSession, setSessionTitle, summarizeConversation, newSessionId, type SessionMeta } from '../session/store.js'
+import { setTerminalTitle, resetTerminalTitle } from './terminalTitle.js'
 import { FilePicker, parseMention, searchFiles } from './FilePicker.js'
 import { ChatView } from './ChatView.js'
 import { useAgentRunner } from './hooks/useAgentRunner.js'
@@ -47,6 +48,10 @@ export function App() {
 
   // --- sessions ---
   const [sessionId, setSessionId] = useState(() => newSessionId())
+  // Live mirror of sessionId so async callbacks can check the *current* active
+  // session, not the one captured when they started.
+  const sessionIdRef = useRef(sessionId)
+  sessionIdRef.current = sessionId
   const [sessions, setSessions] = useState<SessionMeta[]>([])
   const [notice, setNotice] = useState<string | null>(null)
 
@@ -74,6 +79,9 @@ export function App() {
     })
   }, [])
 
+  // Restore the terminal tab title when miii exits (component unmounts).
+  useEffect(() => resetTerminalTitle, [])
+
   // Tracks sessions whose LLM title has been generated, so we summarise once.
   const titledSessions = useRef<Set<string>>(new Set())
 
@@ -98,6 +106,8 @@ export function App() {
         try {
           const title = await summarizeConversation(model, snapshot)
           setSessionTitle(id, title)
+          // Reflect the summary in the terminal tab title, if still the active session.
+          if (id === sessionIdRef.current) setTerminalTitle(title)
         } catch { /* best-effort */ }
       })()
     }

--- a/src/ui/hooks/useKeyboard.ts
+++ b/src/ui/hooks/useKeyboard.ts
@@ -14,6 +14,7 @@ import { filteredCommands } from '../CommandPalette.js'
 import { parseMention, searchFiles } from '../FilePicker.js'
 import { toggleThinkingVisible } from '../ThinkingBlock.js'
 import { toggleToolExpanded } from '../toolExpand.js'
+import { setTerminalTitle, resetTerminalTitle } from '../terminalTitle.js'
 import {
   persistSession,
   listSessions,
@@ -344,6 +345,7 @@ export function useKeyboard(opts: KeyboardOptions) {
         setActiveToolResults([])
         setError(null)
         setSessionId(meta.id)
+        setTerminalTitle(meta.title)
         onResumeSession(meta.id)
         setNotice(`resumed · ${meta.title}`)
         setState('ready')
@@ -457,6 +459,7 @@ export function useKeyboard(opts: KeyboardOptions) {
           // a fresh session id and wipe the chat.
           if (agentHistory.length) setNotice('session saved')
           setSessionId(newSessionId())
+          resetTerminalTitle()
           hardClear()
           clearSession()
         } else if (trimmed === '/sessions') {

--- a/src/ui/terminalTitle.ts
+++ b/src/ui/terminalTitle.ts
@@ -1,0 +1,27 @@
+/**
+ * Set the terminal tab/window title to the active session summary, Claude
+ * Code-style, so a backgrounded `miii` tab reads "✳ Fix the auth bug" instead
+ * of the bare process name (`node`). Uses the OSC 2 escape (window title);
+ * harmless on terminals that ignore it. No-op when stdout isn't a TTY.
+ */
+const OSC = '\x1b]2;'
+const BEL = '\x07'
+
+/** Sanitise to a single safe line — strip control chars/newlines, clamp length. */
+function clean(title: string): string {
+  // eslint-disable-next-line no-control-regex
+  return title.replace(/[\x00-\x1f\x7f]/g, ' ').replace(/\s+/g, ' ').trim().slice(0, 80)
+}
+
+/** Set the terminal title to `✳ <title>`; clears it when title is empty. */
+export function setTerminalTitle(title: string): void {
+  if (!process.stdout.isTTY) return
+  const text = clean(title)
+  const label = text ? `✳ ${text}` : ''
+  process.stdout.write(`${OSC}${label}${BEL}`)
+}
+
+/** Restore the terminal title to the default on exit. */
+export function resetTerminalTitle(): void {
+  setTerminalTitle('')
+}


### PR DESCRIPTION
Set the terminal tab/window title (OSC 2) to the active session's summary, Claude Code-style, and restore it on exit/unmount. Also let ollama callers disable thinking so summarize doesn't burn its budget on hidden reasoning and emit no title.