### PR TITLE
fix: harden config/context/permissions and smooth first-run UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,31 @@ Your code never leaves your disk. There's nothing to log in to. Pull a model, ty
 
 ## Try it in 30 seconds
 
+**macOS / Linux:**
+
 ```bash
 ollama pull qwen2.5-coder:14b   # any coding model works
 curl -fsSL https://raw.githubusercontent.com/maruakshay/miii-cli/main/install.sh | sh
 miii
 ```
 
-Prefer npm? `npm install -g miii-agent`.
+**Windows (PowerShell):**
+
+```powershell
+ollama pull qwen2.5-coder:14b
+irm https://raw.githubusercontent.com/maruakshay/miii-cli/main/install.ps1 | iex
+miii
+```
+
+Prefer npm? `npm install -g miii-agent` works on every platform.
+
+> **Install failing on permissions?** Your global npm prefix isn't writable. The
+> installer retries with `sudo` where available; otherwise point npm at a
+> user-owned prefix and re-run:
+> ```bash
+> npm config set prefix "$HOME/.npm-global"
+> export PATH="$HOME/.npm-global/bin:$PATH"   # add to ~/.bashrc or ~/.zshrc
+> ```
 
 Then just talk to it:
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,52 @@
+#!/usr/bin/env pwsh
+# miii installer / updater (Windows)
+#
+#   irm https://raw.githubusercontent.com/maruakshay/miii-cli/main/install.ps1 | iex
+#
+# Re-run any time to update to the latest release.
+$ErrorActionPreference = 'Stop'
+$Pkg = 'miii-agent'
+
+function Info($m) { Write-Host "==> $m" -ForegroundColor Green }
+function Warn($m) { Write-Host "!! $m"  -ForegroundColor Yellow }
+function Die($m)  { Write-Host "xx $m"  -ForegroundColor Red; exit 1 }
+
+# --- Node ---
+if (-not (Get-Command node -ErrorAction SilentlyContinue)) {
+  Die "Node.js not found. Install Node >= 18 from https://nodejs.org"
+}
+$major = [int](node -p "process.versions.node.split('.')[0]")
+if ($major -lt 18) { Die "Node >= 18 required (found $(node -v)). Upgrade from https://nodejs.org" }
+
+# --- npm ---
+if (-not (Get-Command npm -ErrorAction SilentlyContinue)) {
+  Die "npm not found. It ships with Node.js -- reinstall from https://nodejs.org"
+}
+
+# Detect install vs update for nicer messaging.
+npm ls -g $Pkg *> $null
+if ($LASTEXITCODE -eq 0) { Info "Updating $Pkg to the latest release..." }
+else                     { Info "Installing $Pkg..." }
+
+npm i -g "$Pkg@latest"
+if ($LASTEXITCODE -ne 0) {
+  Warn "Global install failed -- usually a permissions or npm-prefix issue."
+  Write-Host "   Fix option A: run this shell as Administrator and re-run."
+  Write-Host "   Fix option B: use a user-writable npm prefix, then re-run:"
+  Write-Host "     npm config set prefix `"$env:APPDATA\npm`""
+  Write-Host "     # ensure %APPDATA%\npm is on your PATH"
+  Die "Install failed."
+}
+
+$version = try { miii --version 2>$null } catch { '' }
+if ($version) { Info "Done. ($Pkg $version)" } else { Info "Done." }
+
+# --- Ollama hint ---
+if (-not (Get-Command ollama -ErrorAction SilentlyContinue)) {
+  Warn "Ollama not detected. miii needs a local model server."
+  Write-Host "   Install: https://ollama.com/download"
+  Write-Host "   Then:    ollama pull qwen2.5-coder:14b"
+}
+
+Write-Host ""
+Write-Host "Run miii to start." -ForegroundColor Green

--- a/install.sh
+++ b/install.sh
@@ -35,7 +35,11 @@ elif command -v sudo >/dev/null 2>&1; then
   warn "Global install needs elevated permissions — retrying with sudo."
   sudo npm i -g "${PKG}@latest"
 else
-  die "Install failed and sudo is unavailable. Fix your npm prefix or run as a user that can write to it."
+  warn "Global install failed and sudo is unavailable — likely your npm prefix isn't writable."
+  printf '%s\n' "${DIM}   Point npm at a user-owned prefix, then re-run this installer:${RESET}" >&2
+  printf '%s\n' "${DIM}     npm config set prefix \"\$HOME/.npm-global\"${RESET}" >&2
+  printf '%s\n' "${DIM}     export PATH=\"\$HOME/.npm-global/bin:\$PATH\"   # add to ~/.bashrc or ~/.zshrc${RESET}" >&2
+  die "Install failed."
 fi
 
 VERSION="$(miii --version 2>/dev/null || npm view "$PKG" version 2>/dev/null || echo '')"

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -6,7 +6,7 @@ import { validateInput, exampleInput } from '../tools/validate.js'
 import { buildSystemPrompt } from '../prompt/system.js'
 import { loadProjectContext } from '../prompt/context.js'
 import { check, type PermissionContext } from '../permissions/policy.js'
-import { loadConfig, EFFORT_OPTIONS } from '../config.js'
+import { loadConfig, EFFORT_OPTIONS, DEFAULT_NUM_CTX_CAP } from '../config.js'
 import { HookBus } from '../hooks/bus.js'
 import {
   toOllamaMessages,
@@ -143,9 +143,16 @@ export async function* runAgent(opts: RunAgentOpts): AsyncGenerator<AgentEvent, 
   const system = buildSystemPrompt(TOOLS, cwd, loadProjectContext(cwd))
   const ollamaTools = toOllamaTools(TOOLS)
   const toolNames = TOOLS.map((t) => t.name)
+  const cfg = loadConfig()
   // Effort drives temperature + output cap. high → num_predict -1 (unlimited),
   // which ollama.chat omits so the model runs to its own stop.
-  const effort = EFFORT_OPTIONS[loadConfig().effort ?? 'medium']
+  const effort = EFFORT_OPTIONS[cfg.effort ?? 'medium']
+  // Cap the requested context window so a model advertising a huge training
+  // window (e.g. 131072) doesn't make Ollama allocate a KV cache that OOMs the
+  // machine. Override with numCtxCap in config.json. Never raises a small window.
+  const ctxCap = cfg.numCtxCap && cfg.numCtxCap > 0 ? cfg.numCtxCap : DEFAULT_NUM_CTX_CAP
+  const cappedCtx =
+    typeof num_ctx === 'number' && num_ctx > 0 ? Math.min(num_ctx, ctxCap) : undefined
 
   const history: MiiMessage[] = [
     ...opts.history,
@@ -166,6 +173,11 @@ export async function* runAgent(opts: RunAgentOpts): AsyncGenerator<AgentEvent, 
   let leakNudges = 0
   // Canonical paths the model has read (or written) this run — gates edit/write.
   const seenPaths = new Set<string>()
+
+  // Set when the model finishes on its own (end_turn). If we fall out of the
+  // loop with this still false, we hit MAX_TURNS mid-task — surface it instead
+  // of yielding a bare `done`, which reads as "completed successfully".
+  let endedCleanly = false
 
   for (let turn = 0; turn < MAX_TURNS; turn++) {
     let text = ''
@@ -188,7 +200,7 @@ export async function* runAgent(opts: RunAgentOpts): AsyncGenerator<AgentEvent, 
     if (signal) signal.addEventListener('abort', () => ac.abort(), { once: true })
 
     try {
-      for await (const chunk of chat(model, toOllamaMessages(history, system), ollamaTools, { signal: composedSignal, num_ctx, num_predict: effort.num_predict, temperature: effort.temperature })) {
+      for await (const chunk of chat(model, toOllamaMessages(history, system), ollamaTools, { signal: composedSignal, num_ctx: cappedCtx, num_predict: effort.num_predict, temperature: effort.temperature })) {
         if (signal?.aborted) break
         if (chunk.content) {
           text += chunk.content
@@ -291,6 +303,7 @@ export async function* runAgent(opts: RunAgentOpts): AsyncGenerator<AgentEvent, 
         yield { type: 'turn-end', stop_reason: 'tool_use' }
         continue
       }
+      endedCleanly = true
       yield { type: 'turn-end', stop_reason: 'end_turn' }
       break
     }
@@ -409,6 +422,12 @@ export async function* runAgent(opts: RunAgentOpts): AsyncGenerator<AgentEvent, 
     yield { type: 'turn-end', stop_reason: 'tool_use' }
   }
 
+  if (!endedCleanly) {
+    yield {
+      type: 'error',
+      message: `Stopped after ${MAX_TURNS} tool-use turns — the task may be incomplete. Send another message to continue where it left off.`,
+    }
+  }
   yield { type: 'done', prompt_tokens: promptTokens, eval_tokens: evalTokens }
   return history
 }

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -3,7 +3,7 @@ import { render } from 'ink'
 import { createElement } from 'react'
 import { App } from './ui/App.js'
 import { cleanupSpill } from './tools/spill.js'
-import { setProvider, listProviders, type Provider } from './config.js'
+import { setProvider, listProviders, configError, type Provider } from './config.js'
 
 // Drop yesterday's spilled tool output before starting. Best-effort.
 cleanupSpill()
@@ -36,6 +36,11 @@ if (cmd === 'version' || cmd === '--version' || cmd === '-v') {
   const { runEval } = await import('../eval/run.js')
   process.exit(await runEval(rest))
 } else {
+  // Warn about a malformed config BEFORE Ink mounts — once the TUI owns the
+  // terminal, a raw stderr write gets scrambled or painted over.
+  const cfgErr = configError()
+  if (cfgErr) console.error(cfgErr)
+
   // Restore the terminal tab title on any exit path (Ink's unmount cleanup
   // can be skipped on a hard signal).
   process.on('exit', () => { if (process.stdout.isTTY) process.stdout.write('\x1b]2;\x07') })

--- a/src/config.ts
+++ b/src/config.ts
@@ -28,10 +28,22 @@ export interface Config {
   // When true (default), a detected newer release is installed in the background
   // on launch. Set false to keep the manual `miii update` flow only.
   autoUpdate?: boolean
+  // Upper bound on num_ctx sent to Ollama. Models advertise huge training
+  // windows (e.g. 131072); allocating that as KV cache OOMs / slows small
+  // machines. We cap the requested window at this value. Raise it if you have
+  // the VRAM/RAM. See DEFAULT_NUM_CTX_CAP.
+  numCtxCap?: number
   // legacy fields — migrated into `providers` on load
   ollamaHost?: string
   lmstudioHost?: string
 }
+
+// Default ceiling on the context window we ask Ollama to allocate. A model's
+// advertised max context (context_length) is a training limit, not a
+// suggestion — passing it verbatim as num_ctx makes Ollama size its KV cache to
+// the full window, which OOMs or falls back to slow CPU offload on laptops. Cap
+// the request here; override per-machine with `numCtxCap` in config.json.
+export const DEFAULT_NUM_CTX_CAP = 16384
 
 // num_predict caps the output tokens per turn. It must be large enough to hold a
 // full file written inline in a tool call — at 1k/2k whole-file writes (an HTML
@@ -74,6 +86,7 @@ function migrate(raw: Config): Config {
     providers,
     modelContexts: raw.modelContexts,
     autoUpdate: raw.autoUpdate,
+    numCtxCap: raw.numCtxCap,
   }
 }
 
@@ -94,6 +107,25 @@ function readRawConfig(): Config {
     return JSON.parse(readFileSync(CONFIG_PATH, 'utf-8')) as Config
   } catch {
     return {}
+  }
+}
+
+// Detect a malformed config so the CLI can warn the user before it silently
+// falls back to defaults (which would wipe their model/provider/effort). Returns
+// a human-readable message, or null when the file is absent or valid. Must be
+// called BEFORE the Ink UI mounts — stderr written under a live TUI frame gets
+// scrambled or painted over. See cli.tsx.
+export function configError(): string | null {
+  if (!existsSync(CONFIG_PATH)) return null
+  try {
+    JSON.parse(readFileSync(CONFIG_PATH, 'utf-8'))
+    return null
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    return (
+      `miii: ignoring unreadable ${CONFIG_PATH} (${msg}).\n` +
+      `      Running with defaults. Fix the JSON or delete the file to reset.`
+    )
   }
 }
 

--- a/src/permissions/policy.test.ts
+++ b/src/permissions/policy.test.ts
@@ -38,7 +38,6 @@ describe('globToRegExp', () => {
 
 describe('generalizeCommand', () => {
   it('keeps only the program for non-wrapper commands', () => {
-    expect(generalizeCommand("git commit -m 'x'")).toBe('git *')
     expect(generalizeCommand('node script.js')).toBe('node *')
   })
 
@@ -49,23 +48,65 @@ describe('generalizeCommand', () => {
     expect(generalizeCommand('brew list --versions')).toBe('brew list *')
   })
 
+  it('scopes git to its subcommand instead of the whole program', () => {
+    expect(generalizeCommand("git commit -m 'x'")).toBe('git commit *')
+    expect(generalizeCommand('git status -s')).toBe('git status *')
+  })
+
+  // Pins git into the two-token (wrapper) path. If a refactor drops git from
+  // WRAPPER_PROGRAMS, git would collapse to "git *" and this breaks loudly.
+  it('git is a wrapper program — never collapses to "git *"', () => {
+    expect(generalizeCommand('git commit -m x')).not.toBe('git *')
+    expect(generalizeCommand('git log --oneline')).toBe('git log *')
+  })
+
+  // Everyday git ops stay on normal subcommand scoping (not exact-match).
+  it('scopes non-destructive git subcommands rather than forcing exact', () => {
+    expect(generalizeCommand('git checkout main')).toBe('git checkout *')
+    expect(generalizeCommand('git restore src/a.ts')).toBe('git restore *')
+    expect(generalizeCommand('git branch -d feature')).toBe('git branch *')
+  })
+
   it('falls back to one token when a wrapper has no subcommand', () => {
     expect(generalizeCommand('npm')).toBe('npm *')
+    expect(generalizeCommand('git')).toBe('git *')
   })
 
   it('collapses repeated whitespace', () => {
-    expect(generalizeCommand('git   status')).toBe('git *')
+    expect(generalizeCommand('npm   run   build')).toBe('npm run *')
+  })
+
+  it('never generalizes destructive programs — persists the exact command', () => {
+    expect(generalizeCommand('rm -rf build')).toBe('rm -rf build')
+    expect(generalizeCommand('sudo apt install x')).toBe('sudo apt install x')
+    expect(generalizeCommand('dd if=/dev/zero of=disk')).toBe('dd if=/dev/zero of=disk')
+  })
+
+  it('never generalizes destructive git subcommands', () => {
+    expect(generalizeCommand('git reset --hard')).toBe('git reset --hard')
+    expect(generalizeCommand('git clean -fd')).toBe('git clean -fd')
+    expect(generalizeCommand('git push --force')).toBe('git push --force')
+  })
+
+  it('an approved git commit does NOT auto-allow git reset', () => {
+    const rule = generalizeCommand('git commit -m "a"')
+    expect(globToRegExp(rule).test('git commit -m "b"')).toBe(true)
+    expect(globToRegExp(rule).test('git reset --hard')).toBe(false)
   })
 
   it('generalizes the resulting glob to match later variants', () => {
-    expect(globToRegExp(generalizeCommand('git commit -m "a"')).test('git push origin')).toBe(true)
+    expect(globToRegExp(generalizeCommand('npm run build')).test('npm run test')).toBe(true)
     expect(globToRegExp(generalizeCommand('npm run build')).test('npm install x')).toBe(false)
   })
 })
 
 describe('patternToPersist', () => {
   it('generalizes run_bash commands', () => {
-    expect(patternToPersist('run_bash', "git commit -m 'x'")).toBe('git *')
+    expect(patternToPersist('run_bash', "git commit -m 'x'")).toBe('git commit *')
+  })
+
+  it('keeps destructive commands exact', () => {
+    expect(patternToPersist('run_bash', 'rm -rf node_modules')).toBe('rm -rf node_modules')
   })
 
   it('leaves path subjects untouched', () => {

--- a/src/permissions/policy.ts
+++ b/src/permissions/policy.ts
@@ -71,7 +71,9 @@ export function subjectFor(toolName: string, input: unknown): string {
 /**
  * Wrapper programs that dispatch to a subcommand. For these we keep the first
  * two tokens (e.g. "npm run", "npx tsc") so the persisted rule scopes to that
- * subcommand rather than the whole program.
+ * subcommand rather than the whole program. `git` is included so an approval of
+ * "git commit" does not widen into "git *" — which would silently auto-allow
+ * "git reset --hard" / "git clean -fd" on later turns.
  */
 const WRAPPER_PROGRAMS = new Set([
   'npm',
@@ -85,18 +87,66 @@ const WRAPPER_PROGRAMS = new Set([
   'docker',
   'kubectl',
   'go',
+  'git',
+])
+
+/**
+ * Programs destructive enough that one "always" must never become a wildcard —
+ * we persist the exact command instead, so only that literal invocation is
+ * auto-allowed and anything else re-prompts.
+ */
+const NEVER_GENERALIZE = new Set([
+  'rm',
+  'rmdir',
+  'dd',
+  'mkfs',
+  'shred',
+  'truncate',
+  'shutdown',
+  'reboot',
+  'halt',
+  'poweroff',
+  'kill',
+  'killall',
+  'pkill',
+  'chmod',
+  'chown',
+  'mv',
+  'sudo',
+  'doas',
+])
+
+/**
+ * git subcommands that irreversibly discard work or rewrite history. Approving
+ * one of these must not widen to "git <sub> *" (e.g. "git push" → "git push
+ * --force"): persist the exact command so only that invocation is auto-allowed.
+ * Deliberately narrow — checkout/restore/branch are everyday operations and stay
+ * on the normal "git <sub> *" scoping so they don't nag on every variant.
+ */
+const DESTRUCTIVE_GIT_SUBCOMMANDS = new Set([
+  'reset',
+  'clean',
+  'push',
+  'rebase',
+  'filter-branch',
 ])
 
 /**
  * Turn a concrete command into a generalized glob to persist on "always".
- * "git commit -m '...'" → "git *", "npm run build" → "npm run *",
- * "npx tsc --noEmit" → "npx tsc *". Without this we would store the exact
- * literal command and re-prompt on the next slightly different invocation.
+ * "npm run build" → "npm run *", "npx tsc --noEmit" → "npx tsc *",
+ * "git commit -m '...'" → "git commit *". Destructive commands (rm, dd, sudo,
+ * "git reset", …) are NOT generalized — the exact command is persisted so a
+ * single approval can't blanket-authorize a whole dangerous program.
  */
 export function generalizeCommand(command: string): string {
-  const tokens = command.trim().split(/\s+/)
+  const trimmed = command.trim()
+  const tokens = trimmed.split(/\s+/)
   if (tokens.length === 0 || tokens[0] === '') return command
   const prog = tokens[0]
+  if (NEVER_GENERALIZE.has(prog)) return trimmed
+  if (prog === 'git' && tokens.length > 1 && DESTRUCTIVE_GIT_SUBCOMMANDS.has(tokens[1])) {
+    return trimmed
+  }
   const prefixLen = WRAPPER_PROGRAMS.has(prog) && tokens.length > 1 ? 2 : 1
   const prefix = tokens.slice(0, prefixLen).join(' ')
   return `${prefix} *`

--- a/src/tools/run_bash.ts
+++ b/src/tools/run_bash.ts
@@ -14,7 +14,7 @@ export const run_bash: Tool<Input> = {
     type: 'object',
     properties: {
       command:    { type: 'string', description: 'Shell command to run' },
-      timeout_ms: { type: 'number', description: 'Timeout in ms (default 30000)' },
+      timeout_ms: { type: 'number', description: 'Timeout in ms (default 120000). Raise it for long builds/test suites.' },
     },
     required: ['command'],
   },
@@ -24,7 +24,7 @@ export const run_bash: Tool<Input> = {
       const shell = isWin ? 'cmd' : 'bash'
       const shellArgs = isWin ? ['/c', command] : ['-c', command]
       const { stdout, stderr, exitCode } = await execa(shell, shellArgs, {
-        timeout: timeout_ms ?? 30000,
+        timeout: timeout_ms ?? 120000,
         reject: false,
         all: false,
       })

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -247,6 +247,7 @@ export function App() {
           model={cfg.model}
           host={provEntry.baseUrl}
           provider={provName}
+          providerType={provEntry.type}
           effort={effort}
           query={pickerQuery}
           requireSelection={state === 'select-model'}

--- a/src/ui/ModelsView.tsx
+++ b/src/ui/ModelsView.tsx
@@ -1,5 +1,5 @@
 import { Box, Text } from 'ink'
-import type { Effort } from '../config.js'
+import type { Effort, ProviderType } from '../config.js'
 
 interface Props {
   models: string[]
@@ -7,13 +7,14 @@ interface Props {
   model: string | undefined
   host: string
   provider: string
+  providerType?: ProviderType
   effort: Effort
   query: string
   /** true on the initial forced pick (no model yet) — hides "esc back". */
   requireSelection?: boolean
 }
 
-export function ModelsView({ models, cursor, model, host, provider, effort, query, requireSelection }: Props) {
+export function ModelsView({ models, cursor, model, host, provider, providerType, effort, query, requireSelection }: Props) {
   return (
     <Box flexDirection="column" marginLeft={2}>
       <Box flexDirection="column" marginBottom={1}>
@@ -29,13 +30,18 @@ export function ModelsView({ models, cursor, model, host, provider, effort, quer
       <Text dimColor>select model</Text>
       <Box marginTop={1} flexDirection="column" borderStyle="round" borderColor="gray" paddingX={1}>
         {models.length === 0 ? (
-          <Text dimColor>
-            {query
-              ? `no models match "${query}"`
-              : provider === 'lmstudio'
-                ? 'no models. load a model in LM Studio and start the server.'
-                : 'no models found.'}
-          </Text>
+          query ? (
+            <Text dimColor>{`no models match "${query}"`}</Text>
+          ) : provider === 'lmstudio' ? (
+            <Text dimColor>no models. load a model in LM Studio and start the server.</Text>
+          ) : providerType === 'ollama' ? (
+            <Box flexDirection="column">
+              <Text dimColor>no models installed. pull one, then relaunch:</Text>
+              <Text color="cyan">  ollama pull qwen2.5-coder:14b</Text>
+            </Box>
+          ) : (
+            <Text dimColor>{`no models found at ${host}. make sure the server is running with a model loaded.`}</Text>
+          )
         ) : (
           models.map((m, i) => {
             const sel = i === cursor

--- a/src/ui/PermissionPrompt.tsx
+++ b/src/ui/PermissionPrompt.tsx
@@ -1,6 +1,7 @@
 import { Box, Text } from 'ink'
 import type { PermissionRequest } from './types.js'
 import { TOOL_LABEL } from './ToolBlock.js'
+import { subjectFor, patternToPersist } from '../permissions/policy.js'
 
 function summarizeInput(input: unknown): string {
   if (!input || typeof input !== 'object') return ''
@@ -25,9 +26,13 @@ function summarizeInput(input: unknown): string {
 
 export function PermissionPrompt({ req, cursor }: { req: PermissionRequest; cursor: number }) {
   const label = TOOL_LABEL[req.toolName] ?? req.toolName
+  // The glob an "always" choice would persist. Showing it makes the blast radius
+  // explicit — e.g. "npm run *" auto-allows every npm script, while a destructive
+  // command persists exact so it can't blanket-authorize the whole program.
+  const rule = patternToPersist(req.toolName, subjectFor(req.toolName, req.input))
   const options = [
     { label: 'Yes', key: 'yes' },
-    { label: "Yes, don't ask again for this", key: 'always' },
+    { label: rule ? `Yes, don't ask again for ${rule}` : "Yes, don't ask again for this", key: 'always' },
     { label: 'No', key: 'no' },
   ]
   const summary = summarizeInput(req.input)

--- a/src/ui/ThinkingBlock.tsx
+++ b/src/ui/ThinkingBlock.tsx
@@ -4,6 +4,9 @@ import { clipTailVisual, liveFrameRows, contentWidth } from './layout.js'
 
 const FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏']
 
+// Muted chalk tone — soft off-white, quiet against the dim hint next to it.
+const CHALK = '#c9c7c0'
+
 let globalThinkingVisible = false
 const listeners = new Set<() => void>()
 
@@ -33,11 +36,13 @@ export function ThinkingBlock({ content }: { content?: string }) {
     return () => clearInterval(t)
   }, [])
 
+  const label = 'thinking'
+
   return (
     <Box flexDirection="column" marginLeft={2} marginBottom={1}>
       <Box>
-        <Text color="blue">{FRAMES[frame]} </Text>
-        <Text dimColor italic>thinking…</Text>
+        <Text color={CHALK}>{FRAMES[frame]} </Text>
+        <Text color={CHALK} italic>{label}</Text>
         <Text dimColor> · ctrl+t to {visible ? 'hide' : 'show'} thoughts</Text>
       </Box>
       {visible && content ? (() => {


### PR DESCRIPTION
- cap num_ctx (DEFAULT_NUM_CTX_CAP, configurable) so huge advertised windows don't OOM Ollama's KV cache
- warn on malformed config.json before Ink mounts instead of silently resetting to defaults
- raise run_bash default timeout 30s -> 120s
- surface MAX_TURNS exhaustion instead of a silent "done"
- scope permission "always" rules: git -> subcommand, never generalize destructive commands (rm/dd/sudo, git reset/clean/push/rebase), and show the exact rule being persisted in the prompt
- empty-model-list hint (ollama pull …) + provider-aware messaging
- Windows install.ps1 + npm-prefix guidance in install.sh/README
- quieter ThinkingBlock (chalk tone, no shimmer/dots)