### PR TITLE
chore: SEO/docs polish, prompt rules, and TUI flicker fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-<h1 align="center">miii</h1>
+<h1 align="center">miii — Local AI Coding Agent for Your Terminal</h1>
 
 <p align="center">
-  <strong>Cursor / Claude Code, but local.</strong><br>
-  An offline AI pair-programmer in your terminal, powered by Ollama.<br>
-  Private by default. Free forever.
+  <strong>An open-source, offline alternative to Claude Code, Cursor, and GitHub Copilot.</strong><br>
+  A private AI pair-programmer in your terminal, powered by Ollama and any local LLM.<br>
+  Private by default. Free forever. Works offline.
 </p>
 
 <p align="center">
@@ -15,26 +15,41 @@
 </p>
 
 <p align="center">
-  <img src="demo3.gif" alt="miii demo">
+  <img src="demo3.gif" alt="miii local AI coding agent terminal demo powered by Ollama">
+</p>
+
+<p align="center">
+  🔒 <strong>100% local</strong> — your code never leaves your machine &nbsp;·&nbsp;
+  💸 <strong>Free</strong> — no API keys, no per-token billing &nbsp;·&nbsp;
+  ⚡ <strong>Offline</strong> — runs on your own GPU
 </p>
 
 ---
 
-## What is this?
+## What is miii? — a local AI coding agent
 
 miii lives in your terminal and codes alongside you — reading files, writing features, running tests, fixing bugs. The twist: it runs on **your** hardware, powered by [Ollama](https://ollama.com) (or any local OpenAI-compatible server like [llama.cpp](https://github.com/ggml-org/llama.cpp) / [LM Studio](https://lmstudio.ai)).
 
-Your code never leaves your disk. There's nothing to log in to. Pull a model, type `miii`, go.
+Your code never leaves your disk. There's nothing to log in to. Pull a model, type `miii`, go. It's the open-source, offline answer to cloud coding assistants like Claude Code, Cursor, and GitHub Copilot.
 
-## Try it in 30 seconds
+## Install (macOS, Linux, Windows)
 
 **macOS / Linux:**
 
 ```bash
 ollama pull qwen2.5-coder:14b   # any coding model works
+```
+
+**Which model should I use?**
+- **Low VRAM (8GB):** `qwen2.5-coder:7b` (Fast, capable)
+- **Mid VRAM (16-24GB):** `qwen2.5-coder:14b` (Sweet spot)
+- **High VRAM (48GB+):** `qwen2.5-coder:32b` (Powerhouse)
+
+```bash
 curl -fsSL https://raw.githubusercontent.com/maruakshay/miii-cli/main/install.sh | sh
 miii
 ```
+*(The installer downloads the pre-compiled binary and adds it to your local path)*
 
 **Windows (PowerShell):**
 
@@ -77,7 +92,7 @@ miii --version  # what you're running
 Opt out of background updates by adding `"autoUpdate": false` to `~/.miii/config.json`,
 or re-run the install script (`curl … | sh`) any time to update by hand.
 
-## Why local-first?
+## Why local-first? Private, free, offline
 
 Most "AI coding tools" are just wrappers around a cloud API — slow, metered, and they ship your private codebase to someone else's server.
 
@@ -89,13 +104,16 @@ Most "AI coding tools" are just wrappers around a cloud API — slow, metered, a
 | Offline      | No                    | Yes                          |
 | Latency      | Network + queue       | Your GPU only                |
 
-It doesn't just chat, either — it decomposes the problem, calls tools, and checks its own work before claiming victory.
+It doesn't just chat, either — it follows a **Plan $\rightarrow$ Act $\rightarrow$ Observe** loop:
+1. **Plan**: Decomposes the problem into a sequence of concrete steps.
+2. **Act**: Calls the necessary tools to gather context or modify code.
+3. **Observe**: Verifies the result and adjusts the plan until the goal is met.
 
 ## Five letters, five ideas
 
 **s**mall · **s**imple · **s**mart · **s**trategic · **s**emantic — a tiny codebase you can read in an afternoon, no config ceremony, plans before it acts, and operates on the *meaning* of your code, not blind text matching.
 
-## A few things that make it fun
+## Features
 
 - **🧪 `miii doctor`** — not every local model can drive an agent. Doctor runs your models through real engineering tasks and tells you which ones actually deliver.
   ```bash
@@ -189,6 +207,15 @@ The model pages through the middle with ranged `read_file` reads. Spill files ar
 <details>
 <summary><strong>Development</strong></summary>
 
+**Project Architecture:**
+```text
+src/
+ ├── agent/    # The core reasoning loop
+ ├── tools/    # Implementation of read/write/bash
+ ├── terminal/ # UI and input handling
+ └── config/   # Settings and provider logic
+```
+
 ```bash
 git clone https://github.com/maruakshay/miii-cli.git
 cd miii-cli
@@ -210,6 +237,26 @@ npm run build && npm link   # restore later with: npm install -g miii-agent
 </details>
 
 ---
+
+## FAQ
+
+**Does miii work without internet?**
+Yes. Once you've pulled a model with Ollama, miii runs fully offline. No network calls, no account, no cloud.
+
+**Is my code sent anywhere?**
+No. Every file read, edit, and model inference happens on your machine. Your codebase never leaves your disk.
+
+**Which model is best for coding?**
+Depends on VRAM: `qwen2.5-coder:7b` (8GB), `qwen2.5-coder:14b` (16–24GB, the sweet spot), `qwen2.5-coder:32b` (48GB+). Run `miii doctor` to grade your installed models on real engineering tasks.
+
+**How is miii different from Claude Code, Cursor, or GitHub Copilot?**
+Claude Code, Cursor, and Copilot are cloud services — metered, account-gated, and they ship your code to a third-party server. miii is open-source, free, and runs entirely on your hardware. Same terminal-agent workflow as Claude Code, but on your own local model.
+
+**How is it different from Continue.dev?**
+Continue.dev is an IDE extension. miii is a standalone terminal agent — no editor required — with a Plan → Act → Observe loop, permission-gated tools, and lossless output spill built in.
+
+**Do I need a GPU?**
+No, but it helps. Smaller models run on CPU; a GPU makes larger models fast enough for real work.
 
 ## Status
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -45,7 +45,7 @@
   code, kbd, .mono { font-family: var(--mono); }
   ::selection { background: rgba(99,91,255,.35); color: #fff; }
 
-  /* aurora — animated gradient field, Stripe-style */
+  /* aurora — animated gradient field */
   .aurora { position: fixed; inset: -20vh -10vw; z-index: -2; pointer-events: none; filter: blur(70px); opacity: .55; }
   .aurora span { position: absolute; border-radius: 50%; mix-blend-mode: screen; will-change: transform; }
   .b1 { width: 46vw; height: 46vw; left: 50%; top: -8vh; background: radial-gradient(circle, #635bff, transparent 65%); animation: drift1 22s ease-in-out infinite; }
@@ -54,7 +54,7 @@
   @keyframes drift1 { 0%,100%{transform:translate(-50%,0)} 50%{transform:translate(-42%,8vh)} }
   @keyframes drift2 { 0%,100%{transform:translate(0,0)} 50%{transform:translate(8vw,6vh)} }
   @keyframes drift3 { 0%,100%{transform:translate(0,0)} 50%{transform:translate(-6vw,10vh)} }
-  /* fine grid overlay for depth */
+  
   body::before {
     content: ""; position: fixed; inset: 0; z-index: -1; pointer-events: none;
     background-image: linear-gradient(var(--line-soft) 1px, transparent 1px), linear-gradient(90deg, var(--line-soft) 1px, transparent 1px);
@@ -63,20 +63,20 @@
   }
 
   /* nav */
-  nav { position: sticky; top: 0; z-index: 50; backdrop-filter: blur(14px); background: rgba(7,11,22,.66); border-bottom: 1px solid var(--line-soft); }
-  nav .wrap { display: flex; align-items: center; gap: 24px; height: 62px; }
+  nav { position: sticky; top: 0; z-index: 50; backdrop-filter: blur(18px); background: rgba(7,11,22,.75); border-bottom: 1px solid var(--line-soft); }
+  nav .wrap { display: flex; align-items: center; gap: 24px; height: 64px; }
   .brand { font-family: var(--mono); font-weight: 700; font-size: 18px; letter-spacing: -.5px; display: inline-flex; align-items: center; }
   .brand .cursor { color: var(--accent); animation: blink 1.2s steps(1) infinite; }
   @keyframes blink { 50% { opacity: 0; } }
   nav .links { margin-left: auto; display: flex; align-items: center; gap: 24px; font-size: 14px; }
-  nav .links a { color: var(--muted); }
+  nav .links a { color: var(--muted); transition: color .2s; }
   nav .links a:hover { color: var(--fg); }
   nav .links .ship { background: var(--grad); color: #fff; padding: 8px 16px; border-radius: 9px; font-weight: 600; box-shadow: 0 6px 20px rgba(77,141,255,.35); }
   nav .links .ship:hover { color: #fff; filter: brightness(1.08); }
   @media (max-width: 720px) { nav .links a:not(.ship) { display: none; } }
 
   /* hero */
-  header.hero { padding: 96px 0 88px; text-align: center; position: relative; }
+  header.hero { padding: 110px 0 80px; text-align: center; position: relative; }
   .pill { display: inline-flex; align-items: center; gap: 9px; font-family: var(--mono); font-size: 12px; color: var(--accent-2); border: 1px solid var(--line); background: rgba(99,91,255,.08); padding: 6px 14px; border-radius: 999px; margin-bottom: 26px; }
   .pill .dot { width: 7px; height: 7px; border-radius: 50%; background: var(--cyan); box-shadow: 0 0 12px var(--cyan); }
   h1.title { font-size: clamp(42px, 8.4vw, 84px); line-height: 1.0; margin: 0 0 22px; letter-spacing: -2.5px; font-weight: 800; }
@@ -84,14 +84,15 @@
   .tagline { font-family: var(--mono); color: var(--accent-2); font-size: clamp(13px,2.2vw,17px); letter-spacing: 1px; margin-bottom: 20px; }
   .sub { font-size: clamp(16px,2.3vw,21px); color: var(--muted); max-width: 660px; margin: 0 auto 36px; }
   .cta { display: flex; gap: 14px; justify-content: center; flex-wrap: wrap; }
-  .btn { font-family: var(--mono); font-size: 15px; font-weight: 600; padding: 13px 24px; border-radius: 11px; border: 1px solid var(--line); display: inline-flex; align-items: center; gap: 9px; cursor: pointer; transition: transform .18s cubic-bezier(.22,1,.36,1), filter .18s, border-color .18s; }
+  .btn { font-family: var(--mono); font-size: 15px; font-weight: 600; padding: 13px 24px; border-radius: 11px; border: 1px solid var(--line); display: inline-flex; align-items: center; gap: 9px; cursor: pointer; transition: all .2s cubic-bezier(.22,1,.36,1); position: relative; overflow: hidden; }
   .btn:hover { transform: translateY(-2px); }
   .btn.primary { background: var(--grad); color: #fff; border-color: transparent; box-shadow: 0 10px 30px rgba(77,141,255,.4); }
-  .btn.primary:hover { filter: brightness(1.07); }
+  .btn.primary::after { content: ""; position: absolute; inset: 0; background: linear-gradient(90deg, transparent, rgba(255,255,255,.2), transparent); transform: translateX(-100%); transition: transform 0.6s; }
+  .btn.primary:hover::after { transform: translateX(100%); }
   .btn.ghost { background: rgba(255,255,255,.03); color: var(--fg); }
-  .btn.ghost:hover { border-color: var(--accent); }
+  .btn.ghost:hover { border-color: var(--accent); background: rgba(255,255,255,.06); }
 
-  /* hero showcase card */
+  /* showcase window */
   .showcase { margin: 64px auto 0; max-width: 760px; perspective: 1600px; }
   .win { text-align: left; background: linear-gradient(180deg, var(--panel), var(--panel-2)); border: 1px solid var(--line); border-radius: 16px; overflow: hidden; box-shadow: 0 40px 100px -20px rgba(3,6,18,.9), 0 0 0 1px rgba(99,91,255,.08); transform: rotateX(7deg) translateY(0); transform-origin: top center; transition: transform .5s cubic-bezier(.22,1,.36,1); }
   .showcase:hover .win { transform: rotateX(0deg); }
@@ -99,8 +100,8 @@
   .win-bar .ledge { width: 9px; height: 9px; border-radius: 50%; background: var(--accent); box-shadow: 0 0 10px var(--accent); }
   .win-bar .name { font-family: var(--mono); font-size: 12px; color: var(--muted); }
   .win-bar .meta { margin-left: auto; font-family: var(--mono); font-size: 11px; color: var(--dim); }
-  .win-body { padding: 20px 22px; font-family: var(--mono); font-size: 13.5px; line-height: 1.85; }
-  .win-body .row { display: block; white-space: pre-wrap; }
+  .win-body { padding: 20px 22px; font-family: var(--mono); font-size: 13.5px; line-height: 1.85; min-height: 240px; }
+  .win-body .row { display: block; white-space: pre-wrap; margin-bottom: 4px; }
   .win-body .u { color: var(--fg); }
   .win-body .u .pr { color: var(--cyan); }
   .win-body .sys { color: var(--dim); }
@@ -126,7 +127,7 @@
   /* compare */
   .compare { display: grid; grid-template-columns: 1fr 1fr; gap: 20px; }
   @media (max-width: 720px){ .compare { grid-template-columns: 1fr; } }
-  .col { border-radius: 18px; padding: 26px; border: 1px solid var(--line); }
+  .col { border-radius: 18px; padding: 26px; border: 1px solid var(--line); transition: border-color .2s; }
   .col.cloud { background: var(--panel-2); }
   .col.local { background: var(--grad-soft); border-color: rgba(99,91,255,.4); position: relative; }
   .col.local::after { content: ""; position: absolute; inset: 0; border-radius: 18px; padding: 1px; background: var(--grad); -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0); -webkit-mask-composite: xor; mask-composite: exclude; opacity: .5; pointer-events: none; }
@@ -141,9 +142,9 @@
 
   /* feature grid */
   .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px,1fr)); gap: 18px; }
-  .card { background: linear-gradient(180deg, var(--panel), var(--panel-2)); border: 1px solid var(--line); border-radius: 16px; padding: 24px; transition: border-color .2s, transform .2s; position: relative; overflow: hidden; }
+  .card { background: linear-gradient(180deg, var(--panel), var(--panel-2)); border: 1px solid var(--line); border-radius: 16px; padding: 24px; transition: all .3s cubic-bezier(.22,1,.36,1); position: relative; overflow: hidden; }
   .card::before { content: ""; position: absolute; inset: 0; background: radial-gradient(420px circle at var(--mx,50%) var(--my,0%), rgba(99,91,255,.14), transparent 45%); opacity: 0; transition: opacity .25s; pointer-events: none; }
-  .card:hover { border-color: rgba(99,91,255,.5); transform: translateY(-3px); }
+  .card:hover { border-color: rgba(99,91,255,.5); transform: translateY(-4px); box-shadow: 0 12px 30px rgba(3,6,18,.5); }
   .card:hover::before { opacity: 1; }
   .card .ico { width: 42px; height: 42px; border-radius: 11px; display: grid; place-items: center; font-size: 20px; margin-bottom: 16px; background: var(--grad-soft); border: 1px solid rgba(99,91,255,.3); }
   .card h3 { margin: 0 0 8px; font-size: 18px; }
@@ -233,6 +234,19 @@
   </div>
 </header>
 
+<div class="showcase">
+  <div class="win">
+    <div class="win-bar">
+      <div class="ledge"></div>
+      <span class="name">miii — zsh</span>
+      <span class="meta">local-first agent</span>
+    </div>
+    <div class="win-body" id="terminal-sim">
+      <!-- Content populated by JS -->
+    </div>
+  </div>
+</div>
+
 <div class="strip">
   <div class="wrap">
     <span class="lab">Runs on</span>
@@ -246,7 +260,7 @@
 <section id="advantage">
   <div class="wrap reveal">
     <p class="eyebrow">The local-first advantage</p>
-    <h2>Most AI tools rent you a cloud.<br />miii owns the machine.</h2>
+    <h2 style="margin-bottom: 12px;">Most AI tools rent you a cloud.<br />miii owns the machine.</h2>
     <p class="lead">
       Cloud agents are slow, metered, and ask you to trust your private codebase to a third-party server.
       miii flips the script: the model runs on your GPU and your code never touches the wire.
@@ -264,7 +278,7 @@
         <h3>▍ miii <span class="badge">local</span></h3>
         <div class="row2 first"><span class="k">code</span><span class="v">Never leaves your machine</span></div>
         <div class="row2"><span class="k">cost</span><span class="v">Free — runs on your hardware</span></div>
-        <div class="row2"><span class="k">setup</span><span class="v"><code>npm i -g miii-agent</code></span></div>
+        <div class="row2"><span class="k">setup</span><span class="v"><code style="color:var(--accent-2)">npm i -g miii-agent</code></span></div>
         <div class="row2"><span class="k">offline</span><span class="v">Yes</span></div>
         <div class="row2"><span class="k">latency</span><span class="v">Your GPU only</span></div>
       </div>
@@ -281,7 +295,7 @@
       <div class="card"><div class="ico">📖</div><h3>Reads &amp; writes code</h3><p><code>read_file</code>, <code>write_file</code>, <code>edit_file</code> — precise string-level edits with whitespace tolerance, no blind rewrites.</p></div>
       <div class="card"><div class="ico">🔎</div><h3>Searches your repo</h3><p><code>glob</code> + <code>grep</code> with context, type filters, multiline and count modes across the whole project.</p></div>
       <div class="card"><div class="ico">⚡</div><h3>Runs your shell</h3><p><code>run_bash</code> executes commands and tests, so the agent verifies outcomes instead of guessing.</p></div>
-      <div class="card"><div class="ico">🔒</div><h3>Permission-gated</h3><p>Every sensitive op is approved by you. "Always" rules persist to <code>~/.miii/permissions.json</code>. File tools are confined to your workspace.</p></div>
+      <div class="card"><div class="ico">🔒</div><h3>Permission-gated</h3><p>Every sensitive op is approved by you. "Always" rules persist to <code style="color:var(--accent-2)">~/.miii/permissions.json</code>. File tools are confined to your workspace.</p></div>
       <div class="card"><div class="ico">🧾</div><h3>Lossless output spill</h3><p>Huge tool outputs aren't truncated — they spill to disk with a head+tail preview, and the model pages the middle on demand.</p></div>
       <div class="card"><div class="ico">🩺</div><h3>Model doctor</h3><p><code>miii doctor</code> validates your local models against real engineering tasks and tells you which can actually drive the agent.</p></div>
     </div>
@@ -306,7 +320,6 @@ ollama pull qwen2.5-coder:14b</pre>
       <div class="step">
         <h3><span class="n">3</span> Run it</h3>
         <pre><span class="p">miii</span>
-
 <span class="c"># then just talk to it</span>
 <span class="p">&gt;</span> @src/server.ts add rate limiting
 <span class="p">&gt;</span> why are my tests failing?</pre>
@@ -348,8 +361,48 @@ ollama pull qwen2.5-coder:14b</pre>
 </footer>
 
 <script>
-// Changelog is generated at runtime: fetch CHANGELOG.md and parse it in the browser.
-// No build step, no baked HTML — the page reflects the repo's latest release automatically.
+// Dynamic Terminal Simulation
+(function () {
+  const sim = document.getElementById("terminal-sim");
+  const lines = [
+    { t: "miii", c: "u" },
+    { t: "> @src/api.ts implement health check", c: "u pr" },
+    { t: "Searching for api.ts...", c: "sys" },
+    { t: "Running read_file(src/api.ts)", c: "tool" },
+    { t: "Updating src/api.ts...", c: "tool" },
+    { t: "+ export const healthCheck = () => ({ status: 'ok' });", c: "add" },
+    { t: "Verifying change with npm test...", c: "sys" },
+    { t: "✓ all tests passed", c: "ok" },
+    { t: "I've added the health check endpoint to src/api.ts. All tests are green.", c: "u" },
+    { t: "> ", c: "u pr" }
+  ];
+
+  async function typeLine(lineObj) {
+    const row = document.createElement("div");
+    row.className = `row ${lineObj.c}`;
+    sim.appendChild(row);
+    
+    const text = lineObj.t;
+    for (let i = 0; i < text.length; i++) {
+      row.textContent += text[i];
+      await new Promise(r => setTimeout(r, 15 + Math.random() * 20));
+    }
+    if (lineObj.t === "> ") {
+       row.innerHTML += '<span class="caret"></span>';
+    }
+  }
+
+  async function runSim() {
+    for (const line of lines) {
+      await typeLine(line);
+      await new Promise(r => setTimeout(r, 200 + Math.random() * 600));
+    }
+  }
+
+  runSim();
+})();
+
+// Changelog fetcher
 (function () {
   const REPO = "maruakshay/miii-cli";
   const RAW = `https://raw.githubusercontent.com/${REPO}/main/CHANGELOG.md`;
@@ -357,22 +410,15 @@ ollama pull qwen2.5-coder:14b</pre>
   const MAX = 8;
   const el = document.getElementById("timeline");
 
-  const esc = (s) =>
-    s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  const esc = (s) => s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 
-  // Split `text ([sha](url))` (the form release-please appends) into its parts.
   function split(line) {
     const m = line.match(/^(.*?)\s*\(\[([0-9a-f]{7,})\]\((https?:\/\/[^)]+)\)\)\s*$/);
-    return m
-      ? { text: m[1].trim(), sha: m[2] }
-      : { text: line.trim(), sha: null };
+    return m ? { text: m[1].trim(), sha: m[2] } : { text: line.trim(), sha: null };
   }
 
-  // Minimal inline markdown for changelog entries: **bold** and `code`.
   function li({ text, sha }) {
-    const html = esc(text)
-      .replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>")
-      .replace(/`([^`]+)`/g, "<code>$1</code>");
+    const html = esc(text).replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>").replace(/`([^`]+)`/g, "<code>$1</code>");
     if (!sha) return `<li>${html}</li>`;
     return `<li>${html} <a class="sha" href="${COMMIT(sha)}">${sha.slice(0, 7)}</a></li>`;
   }
@@ -395,25 +441,17 @@ ollama pull qwen2.5-coder:14b</pre>
         const it = raw.match(/^\*\s+(.*)$/);
         if (it && cur) {
           const parts = split(it[1].trim());
-          if (seen.has(parts.text)) continue; // release-please double-lists same text
+          if (seen.has(parts.text)) continue;
           seen.add(parts.text);
           groups[cur].push(li(parts));
         }
       }
-      const sections = Object.entries(groups)
-        .filter(([, v]) => v.length)
-        .map(([name, items]) => {
+      const sections = Object.entries(groups).filter(([, v]) => v.length).map(([name, items]) => {
           const cls = /fix/i.test(name) ? "fix" : "feat";
           return `<div class="ch-group ${cls}"><h4>${esc(name)}</h4><ul>${items.join("")}</ul></div>`;
-        })
-        .join("");
+        }).join("");
       if (!sections) continue;
-      out.push(
-        `<article class="release">` +
-          `<header class="release-head"><span class="tag">v${esc(version)}</span>` +
-          (date ? `<time>${esc(date)}</time>` : "") +
-          `</header>${sections}</article>`
-      );
+      out.push(`<article class="release"><header class="release-head"><span class="tag">v${esc(version)}</span>${date ? `<time>${esc(date)}</time>` : ""}</header>${sections}</article>`);
     }
     return out;
   }
@@ -429,9 +467,7 @@ ollama pull qwen2.5-coder:14b</pre>
       });
     })
     .catch(() => {
-      el.innerHTML =
-        '<p class="ch-status err mono">Could not load the changelog. ' +
-        `<a href="https://github.com/${REPO}/blob/main/CHANGELOG.md">Read it on GitHub →</a></p>`;
+      el.innerHTML = '<p class="ch-status err mono">Could not load the changelog. <a href="https://github.com/' + REPO + '/blob/main/CHANGELOG.md">Read it on GitHub →</a></p>';
     });
 })();
 
@@ -451,6 +487,5 @@ ollama pull qwen2.5-coder:14b</pre>
   });
 })();
 </script>
-
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "miii-agent",
   "version": "0.1.30",
-  "description": "Cursor / Claude Code, but local. An offline AI pair-programmer in your terminal, powered by Ollama. Private by default, free forever.",
+  "description": "Local AI coding agent for your terminal — an open-source, offline alternative to Claude Code, Cursor, and GitHub Copilot, powered by Ollama. Private by default, free forever.",
   "type": "module",
   "bin": {
     "miii": "dist/cli.js"
@@ -52,7 +52,14 @@
     "pair-programming",
     "code-generation",
     "llama-cpp",
-    "lm-studio"
+    "lm-studio",
+    "copilot",
+    "copilot-alternative",
+    "cursor-alternative",
+    "claude-code",
+    "claude-code-alternative",
+    "developer-tools",
+    "qwen"
   ],
   "license": "MIT",
   "dependencies": {

--- a/src/prompt/system.ts
+++ b/src/prompt/system.ts
@@ -93,6 +93,7 @@ Ask in a numbered list. One round of questions per turn. Then wait.
 - After a tool result, move directly to the next tool call or the final answer. Do not restate what the previous tool did.
 - Every tool call MUST carry a complete, valid arguments object: all required fields present, correct types, valid JSON. Never emit a call with empty, partial, or placeholder arguments.
 - WRONG (leaks as text, nothing runs): writing \`call:some_tool{"foo":"bar"}\` or a fenced JSON block in your reply. RIGHT: emit it as a native function call with a full arguments object.
+- Batch independent tool calls in a SINGLE turn — parallel, not serial. If two reads, greps, or searches do not depend on each other's output, emit them together. Only serialize when a later call needs an earlier result.
 
 # Tools
 You have access to the following tools. Call them via the function-calling interface.
@@ -102,13 +103,32 @@ ${toolLines}
 - When you need to act on the filesystem or run a command, emit a tool call.
 - After each tool result, decide: more tool calls, or a final plain-text answer.
 - Stop emitting tool calls when GOAL is met. Reply with a concise plain-text final message confirming CRITERION is satisfied.
+- After the work is done, always close by asking the user what they want to do next — a brief, specific prompt (offer the most likely follow-ups when obvious). One line, no filler.
 
 # Rules
 - Always read a file before updating it. Never edit, overwrite, or create-over a file you have not read first this turn.
 - Prefer editing existing files over creating new ones.
+- To change an existing file, use edit_file with a small, targeted old_str/new_str diff — never rewrite the whole file with write_file. Reserve write_file for brand-new files or small ones. A full-file write_file on a large file risks getting cut off at the output token limit mid-write; a targeted edit_file stays small and avoids that.
+- When a new file's content is large, create it with write_file for the first portion, then append the rest with successive edit_file calls. Keep every write small.
 - For edit_file, make old_str unique by including surrounding context, or set replace_all to change every occurrence.
 - Never invent file paths. Read, glob, or grep before editing.
 - No empty filler or robotic boilerplate. A brief, genuine warm touch (see Tone and voice) is welcome; hollow pleasantries and reflexive apologies are not.
+
+# Scope discipline
+- Do ONLY what the user asked. No unrequested refactors, renames, reformatting, or "while I'm here" edits.
+- If you spot an unrelated issue worth fixing, mention it in your final message — do not fix it unprompted.
+- Touch the fewest files needed. A one-line request gets a one-line change, not a redesign.
+
+# Secrets and safety
+- Never print, log, or echo secrets, API keys, tokens, passwords, or \`.env\` values. Redact them if you must reference one.
+- Never write credentials into source, commits, or output. If a secret is needed, read it from the environment or config.
+- Do not exfiltrate file contents to external services without the user asking.
+
+# Git and commits
+- Do NOT commit, push, or create branches/PRs unless the user explicitly asks.
+- When asked to commit: never commit on the main branch — branch first. Stage only files relevant to the change; never blanket \`git add -A\` without checking what it sweeps in.
+- Write a concise commit message stating what changed and why. Do not add credentials or generated noise.
+- Never force-push, rebase shared history, or run destructive git commands without explicit confirmation.
 
 # Context discipline
 - read_file returns line numbers and accepts offset/limit. For large files, grep or glob to the relevant region first, then read only that range with offset/limit. Do not read a whole large file when you need a few functions — it wastes the context window.

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -54,6 +54,9 @@ export function App() {
   sessionIdRef.current = sessionId
   const [sessions, setSessions] = useState<SessionMeta[]>([])
   const [notice, setNotice] = useState<string | null>(null)
+  // Bumped on /clear and /new to remount ChatView's <Static> so the welcome
+  // banner reprints after the hard-clear (Ink won't otherwise reflush it).
+  const [logEpoch, setLogEpoch] = useState(0)
 
   // --- input bar ---
   const [input, setInput] = useState('')
@@ -200,7 +203,7 @@ export function App() {
     input, setInput, caret, setCaret, paletteCursor, setPaletteCursor, filePickerCursor, setFilePickerCursor,
     sessionId, setSessionId,
     onResumeSession: (id) => titledSessions.current.add(id),
-    sessions, setSessions, setNotice,
+    sessions, setSessions, setNotice, setLogEpoch,
     switchProvider,
   })
 
@@ -220,7 +223,7 @@ export function App() {
       {/* Pre-ready screens render the banner dynamically. In ready/chat mode the
           banner moves into ChatView's <Static> log (Ink prints Static above the
           live frame, so a dynamic banner here would sink below the scrollback). */}
-      {state !== 'ready' && (
+      {state !== 'ready' && state !== 'sessions' && state !== 'models' && (
         <WelcomeBlock model={cfg.model} activeCtx={activeCtx} effort={effort} cwd={cwd} error={agent.error} updateAvailable={updateAvailable} updateStatus={updateStatus} />
       )}
 
@@ -240,7 +243,7 @@ export function App() {
         />
       )}
 
-      {(state === 'select-model' || state === 'models') && (
+      {state === 'select-model' && (
         <ModelsView
           models={filteredModels}
           cursor={cursor}
@@ -250,7 +253,7 @@ export function App() {
           providerType={provEntry.type}
           effort={effort}
           query={pickerQuery}
-          requireSelection={state === 'select-model'}
+          requireSelection
         />
       )}
 
@@ -263,11 +266,7 @@ export function App() {
         />
       )}
 
-      {state === 'sessions' && (
-        <SessionsView sessions={sessions} cursor={cursor} />
-      )}
-
-      {state === 'ready' && (
+      {(state === 'ready' || state === 'sessions' || state === 'models') && (
         <>
           {notice && (
             <Box marginLeft={2} marginBottom={1}>
@@ -286,13 +285,14 @@ export function App() {
             activeToolUses={agent.activeToolUses}
             activeToolResults={agent.activeToolResults}
             header={<WelcomeBlock model={cfg.model} activeCtx={activeCtx} effort={effort} cwd={cwd} />}
+            logEpoch={logEpoch}
           />
 
-          {input.startsWith('/') && (
+          {state === 'ready' && input.startsWith('/') && (
             <CommandPalette filter={input} cursor={paletteCursor} />
           )}
 
-          {contextWarning !== null && (
+          {state === 'ready' && contextWarning !== null && (
             <Box marginLeft={2} marginBottom={1}>
               <Text color="yellow">
                 {`⚠ context ${contextWarning}% full — run /clear and start fresh`}
@@ -300,14 +300,37 @@ export function App() {
             </Box>
           )}
 
-          {!input.startsWith('/') && (() => {
+          {state === 'ready' && !input.startsWith('/') && (() => {
             const m = parseMention(input)
             if (!m) return null
             return <FilePicker matches={searchFiles(process.cwd(), m.query)} cursor={filePickerCursor} />
           })()}
 
-          <InputBar input={input} caret={caret} disabled={agent.busy} processingLabel={agent.processingLabel} />
-          {!agent.busy && (
+          {/* Pickers have their own inline controls, so they drop the input bar
+              entirely (avoids a stray "processing" prompt). */}
+          {state === 'ready' && (
+            <InputBar input={input} caret={caret} disabled={agent.busy} processingLabel={agent.processingLabel} />
+          )}
+
+          {/* Pickers render below the input bar (like the command palette) so the
+              single scrollback banner stays put — no duplicate header. */}
+          {state === 'sessions' && (
+            <SessionsView sessions={sessions} cursor={cursor} />
+          )}
+          {state === 'models' && (
+            <ModelsView
+              models={filteredModels}
+              cursor={cursor}
+              model={cfg.model}
+              host={provEntry.baseUrl}
+              provider={provName}
+              providerType={provEntry.type}
+              effort={effort}
+              query={pickerQuery}
+            />
+          )}
+
+          {state === 'ready' && !agent.busy && (
             <Box marginLeft={2} marginBottom={1}>
               <Text dimColor>
                 {providerDown

--- a/src/ui/ChatView.tsx
+++ b/src/ui/ChatView.tsx
@@ -7,7 +7,7 @@ import { EMPTY_STATE_HINTS, EMPTY_STATE_TITLE } from './constants.js'
 import { UserMessage, AssistantMessage } from './Message.js'
 import { ToolUseLine } from './ToolBlock.js'
 import { PermissionPrompt } from './PermissionPrompt.js'
-import { clipTail, liveFrameRows, contentWidth, estimateToolRows } from './layout.js'
+import { clipTail, clipTailVisual, visualHeight, liveFrameRows, contentWidth, estimateToolRows } from './layout.js'
 
 interface Props {
   messages: ChatMessage[]
@@ -23,6 +23,11 @@ interface Props {
   // Rendered once as the first line of the static scrollback log (e.g. the
   // welcome banner). Omitted by pre-ready error views so no banner prints.
   header?: ReactNode
+  // Bumped by /clear and /new. Ink's <Static> only writes each item once and
+  // tracks how many it has flushed, so after a hard-clear shrinks the log back
+  // to just the header it won't reprint it. Using this as the <Static> key
+  // remounts it (index resets to 0) so the header prints again on the clean screen.
+  logEpoch?: number
 }
 
 export function ChatView({
@@ -37,6 +42,7 @@ export function ChatView({
   activeToolUses,
   activeToolResults,
   header,
+  logEpoch = 0,
 }: Props) {
   const empty =
     messages.length === 0 && !streaming && !thinking && !pendingPermission && !error
@@ -64,8 +70,22 @@ export function ChatView({
   let streamNode: ReactNode = null
   let streamRows = 0
   if (streaming && streamingContent) {
-    const { text, clipped } = clipTail(renderMarkdownStreaming(streamingContent), liveBudget)
-    streamRows = text.split('\n').length + (clipped > 0 ? 1 : 0)
+    // Clip the RAW buffer to the live budget first, then parse markdown on just
+    // that tail. Parsing (marked + syntax highlight) is O(input); rendering the
+    // whole accumulated answer every 100ms flush made late flushes on long
+    // replies lag and stutter. Bounding the input to ~terminal height keeps each
+    // flush's cost constant regardless of total answer length.
+    const raw = clipTail(streamingContent, liveBudget)
+    // Second clip is by VISUAL rows, not logical lines: the rendered markdown is
+    // drawn in a `wrap="wrap"` box at contentWidth, so a long line occupies
+    // several terminal rows. Counting logical lines let the live frame exceed the
+    // budget and overflow the terminal, forcing Ink's full-screen clear — the
+    // flicker. Mirrors the thinking block's clipTailVisual sizing.
+    const width = contentWidth()
+    const rendered = clipTailVisual(renderMarkdownStreaming(raw.text), liveBudget, width)
+    const text = rendered.text
+    const clipped = raw.clipped + rendered.clipped
+    streamRows = visualHeight(text, width) + (clipped > 0 ? 1 : 0)
     streamNode = (
       <Box flexDirection="column" marginBottom={1}>
         {clipped > 0 && (
@@ -115,7 +135,7 @@ export function ChatView({
 
   return (
     <>
-      <Static items={log}>
+      <Static key={logEpoch} items={log}>
         {(item) =>
           item.key === 'header' ? (
             <Box key={item.key}>{item.node}</Box>

--- a/src/ui/InputBar.tsx
+++ b/src/ui/InputBar.tsx
@@ -14,7 +14,11 @@ export const InputBar = memo(function InputBar({ input, caret, disabled, process
   const [frame, setFrame] = useState(0)
   useEffect(() => {
     if (!disabled) return
-    const t = setInterval(() => setFrame((f) => (f + 1) % SPIN.length), 150)
+    // 200ms is a clean 2× of the 100ms stream flush (useAgentRunner FLUSH_MS):
+    // the two timers phase-lock instead of beating, so the live frame repaints
+    // on a steady cadence rather than at drifting 100/150ms intervals — the
+    // extra unsynced repaints were a visible flicker source.
+    const t = setInterval(() => setFrame((f) => (f + 1) % SPIN.length), 200)
     return () => clearInterval(t)
   }, [disabled])
 

--- a/src/ui/ThinkingBlock.tsx
+++ b/src/ui/ThinkingBlock.tsx
@@ -32,7 +32,11 @@ export function ThinkingBlock({ content }: { content?: string }) {
   const visible = useThinkingVisible()
 
   useEffect(() => {
-    const t = setInterval(() => setFrame((f) => (f + 1) % FRAMES.length), 80)
+    // Match the agent's FLUSH_MS stream/think cadence. At 80ms the spinner and
+    // the 100ms flush beat against each other, so the tall live frame repaints on
+    // two unsynced clocks — visible shimmer. Aligning them collapses it to one
+    // repaint per tick.
+    const t = setInterval(() => setFrame((f) => (f + 1) % FRAMES.length), 100)
     return () => clearInterval(t)
   }, [])
 

--- a/src/ui/hooks/useAgentRunner.ts
+++ b/src/ui/hooks/useAgentRunner.ts
@@ -167,14 +167,23 @@ export function useAgentRunner(model: string | undefined, activeCtx: number | nu
           case 'turn-end': {
             flushStream(true)
             flushThink(true)
-            setStreaming(false)
             if (ev.stop_reason === 'tool_use') {
+              // Tool turn: clearing `streaming` and committing the turn happen in
+              // the same synchronous tick, so React batches them into one repaint.
+              setStreaming(false)
               flushTurn(null)
               setThinking(true)
               thinkingAcc = ''
               setThinkingContent('')
               firstToken = true
             }
+            // Final turn (non-tool stop): DON'T drop `streaming` here. The commit
+            // (flushTurn with real tokens) can't run until the later 'done' event
+            // lands, and an `await` sits between. Clearing `streaming` now would
+            // paint one frame with the live stream gone but the message not yet in
+            // <Static> — a blank flash, then a full reprint. Leaving `streaming`
+            // true keeps the rendered tail on screen until the post-loop
+            // setStreaming(false)+flushTurn batch swaps it in atomically.
             break
           }
           case 'done': {

--- a/src/ui/hooks/useKeyboard.ts
+++ b/src/ui/hooks/useKeyboard.ts
@@ -181,6 +181,8 @@ interface KeyboardOptions {
   sessions: SessionMeta[]
   setSessions: (s: SessionMeta[]) => void
   setNotice: (s: string | null) => void
+  /** Bumped on /clear and /new to remount the <Static> log and reprint the banner. */
+  setLogEpoch: (fn: (n: number) => number) => void
 
   // provider switching
   switchProvider: (p: Provider) => void
@@ -193,7 +195,7 @@ export function useKeyboard(opts: KeyboardOptions) {
     providers, pickerQuery, setPickerQuery,
     agent,
     input, setInput, caret, setCaret, paletteCursor, setPaletteCursor, filePickerCursor, setFilePickerCursor,
-    sessionId, setSessionId, onResumeSession, sessions, setSessions, setNotice,
+    sessionId, setSessionId, onResumeSession, sessions, setSessions, setNotice, setLogEpoch,
     switchProvider,
   } = opts
 
@@ -228,6 +230,9 @@ export function useKeyboard(opts: KeyboardOptions) {
     setError(null)
     setNotice(null)
     clearPasteStore()
+    // Remount ChatView's <Static> so the welcome banner reprints on the freshly
+    // cleared screen; Ink otherwise treats it as already-flushed and skips it.
+    setLogEpoch((n) => n + 1)
   }
 
   const effort: Effort = cfg.effort ?? 'medium'

--- a/src/ui/layout.ts
+++ b/src/ui/layout.ts
@@ -36,6 +36,26 @@ export function clipTail(rendered: string, max: number): { text: string; clipped
   return { text: lines.slice(-max).join('\n'), clipped: lines.length - max }
 }
 
+// Strip SGR/ANSI escapes so width is measured in VISIBLE columns. Rendered
+// markdown (marked-terminal + syntax highlight) embeds color codes that inflate
+// String#length; counting them as columns over-estimates height and mis-clips.
+const ANSI_RE = /\x1b\[[0-9;]*m/g
+export function stripAnsi(s: string): string {
+  return s.replace(ANSI_RE, '')
+}
+
+// Visible height (terminal rows) of already-rendered text at wrap `width`: each
+// logical line wraps to ceil(visibleLen / width) rows. ANSI codes are stripped
+// first so escape sequences aren't counted as columns.
+export function visualHeight(text: string, width: number): number {
+  const w = Math.max(1, width)
+  let rows = 0
+  for (const line of text.split('\n')) {
+    rows += Math.max(1, Math.ceil(stripAnsi(line).length / w))
+  }
+  return rows
+}
+
 // Clip text to the last lines that fit `maxRows` of VISUAL rows at the given
 // wrap `width` — long lines occupy multiple rows, so a plain line count
 // under-estimates height. Used by the thinking block: clipping by logical lines
@@ -48,7 +68,7 @@ export function clipTailVisual(
 ): { text: string; clipped: number } {
   const w = Math.max(1, width)
   const lines = content.split('\n')
-  const visualRows = (line: string) => Math.max(1, Math.ceil(line.length / w))
+  const visualRows = (line: string) => Math.max(1, Math.ceil(stripAnsi(line).length / w))
   let rows = 0
   let start = lines.length
   for (let i = lines.length - 1; i >= 0; i--) {
@@ -73,9 +93,25 @@ export function liveFrameRows(): number {
 // budget — an overflowing live frame forces Ink's full-screen clear, which is the
 // flicker. The expanded (ctrl+o) view is the user's choice and is not budgeted.
 const COLLAPSED_LINES = 3
+// Visual height of a block of text: each logical line wraps to ceil(len/width)
+// terminal rows. Counting logical lines alone under-estimates a long single-line
+// bash/grep result, letting the live frame overflow the terminal — which forces
+// Ink's full-screen erase, the flicker. Mirrors clipTailVisual's row model.
+function visualRows(text: string, width: number, cap: number): number {
+  const w = Math.max(1, width)
+  let rows = 0
+  const lines = text.split('\n')
+  for (const line of lines) {
+    rows += Math.max(1, Math.ceil(line.length / w))
+    if (rows >= cap) return cap
+  }
+  return rows
+}
+
 export function estimateToolRows(use: ToolUseDisplay, result?: ToolResultDisplay): number {
   const input = (use.input ?? {}) as Record<string, unknown>
   const noErr = !result?.is_error
+  const w = contentWidth()
   // write/edit render a header + summary + (clipped) diff preview.
   if (use.name === 'write_file' && noErr) {
     const total = countLines(String(input.content ?? ''))
@@ -94,10 +130,12 @@ export function estimateToolRows(use: ToolUseDisplay, result?: ToolResultDisplay
       (use.name === 'run_bash' || use.name === 'grep' || use.name === 'glob' || result.is_error) &&
       lines.length > 1
     if (multi) {
-      const shown = Math.min(lines.length, COLLAPSED_LINES)
-      rows += 1 + shown + (lines.length > shown ? 1 : 0)
+      // Only the first COLLAPSED_LINES show; count their WRAPPED height so a
+      // long line isn't mis-budgeted as one row.
+      const shownLines = lines.slice(0, COLLAPSED_LINES).join('\n')
+      rows += 1 + visualRows(shownLines, w, COLLAPSED_LINES * 4) + (lines.length > COLLAPSED_LINES ? 1 : 0)
     } else {
-      rows += 1
+      rows += visualRows(lines[0] ?? '', w, 4)
     }
   }
   return rows


### PR DESCRIPTION
- README/package.json: reframe as local AI coding agent; add FAQ, model guidance, keywords for discoverability
- docs/index.html: animated terminal sim, hover/nav polish, condensed JS
- system prompt: add parallel tool-call batching, scope discipline, secrets/safety, and git-commit rules; prefer targeted edit_file
- TUI: fix live-frame flicker by clipping stream by visual rows and phase-locking spinner timers to the 100ms flush; remount <Static> on /clear so the banner reprints; render sessions/models pickers inside scrollback