### PR TITLE
fix: surface empty/early-dropped Ollama streams

### DIFF
--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -331,6 +331,22 @@ export async function* runAgent(opts: RunAgentOpts): AsyncGenerator<AgentEvent, 
         yield { type: 'turn-end', stop_reason: 'tool_use' }
         continue
       }
+      // Turn produced literally nothing — no visible text and no tool call. This
+      // is not a clean end: it usually means the model returned an empty response
+      // (stream dropped mid-request, or the output cap was spent entirely on
+      // hidden thinking tokens). Ending silently here looks to the user like the
+      // run just aborted with no reason. Surface it instead of a bare end_turn.
+      if (assistantText.trim() === '') {
+        yield {
+          type: 'error',
+          message:
+            'The model returned an empty response — likely unloaded/OOM mid-stream or the ' +
+            'output cap was consumed by thinking before any answer. Retry, switch models, or ' +
+            'lower the context/effort.',
+        }
+        yield { type: 'done', prompt_tokens: promptTokens, eval_tokens: evalTokens }
+        return history
+      }
       endedCleanly = true
       yield { type: 'turn-end', stop_reason: 'end_turn' }
       break

--- a/src/llm/ollama.ts
+++ b/src/llm/ollama.ts
@@ -158,9 +158,18 @@ export async function* chat(
     }
     throw err
   }
+  // Track whether the stream produced any real signal (content, thinking, or a
+  // tool call) before it dropped. Only a late drop — after we already have
+  // output — is safe to treat as a clean end. An early drop with nothing yielded
+  // is a genuine failure (model unloaded / OOM / crashed mid-request) and must
+  // surface, not synthesize a blank `done` that ends the turn silently.
+  let sawOutput = false
   try {
     for await (const chunk of stream) {
       if (signal?.aborted) break
+      if (chunk.message.content || (chunk.message as { thinking?: string }).thinking || (chunk.message.tool_calls?.length ?? 0) > 0) {
+        sawOutput = true
+      }
       yield {
         content: stripHarmony(chunk.message.content),
         thinking: stripHarmony((chunk.message as { thinking?: string }).thinking),
@@ -180,13 +189,22 @@ export async function* chat(
     }
     // Cloud Ollama endpoints sometimes close the stream after emitting all
     // content but without a final `done:true` chunk. The ollama SDK treats that
-    // as fatal (AbortableAsyncIterator throws this exact message). We already
-    // have the content, so treat it as a clean end-of-turn: synthesize a done
-    // chunk (token counts unknown → 0) instead of surfacing a red error.
+    // as fatal (AbortableAsyncIterator throws this exact message). If we already
+    // got output, treat it as a clean end-of-turn: synthesize a done chunk (token
+    // counts unknown → 0) instead of surfacing a red error. But an EARLY drop
+    // with nothing yielded is a real failure (model unloaded / OOM / crashed) —
+    // re-throw so it surfaces instead of ending the turn silently.
     const msg = err instanceof Error ? err.message : String(err)
     if (msg.includes('Did not receive done or success response in stream')) {
-      yield { content: '', done: true, prompt_eval_count: 0, eval_count: 0 }
-      return
+      if (sawOutput) {
+        yield { content: '', done: true, prompt_eval_count: 0, eval_count: 0 }
+        return
+      }
+      throw new Error(
+        'Ollama closed the stream before sending any output — the model likely ' +
+        'unloaded, ran out of memory, or crashed mid-request. Check `ollama ps`, ' +
+        'then retry or switch to a smaller model.',
+      )
     }
     throw err
   } finally {


### PR DESCRIPTION
An Ollama stream that closes before emitting any output (model unloaded, OOM, or crashed mid-request) was synthesized into a blank `done` chunk, ending the turn silently with no explanation. Track whether the stream produced real signal and only treat a late drop as a clean end; re-throw early drops. In the agent loop, also surface a turn that produced no text and no tool call as an error instead of a bare end_turn.