### PR TITLE
Add GitHub Sponsors link via .github/FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [maruakshay]


### PR DESCRIPTION
Points the repo's Sponsor button at the existing
github.com/sponsors/maruakshay page. No README or other changes — kept minimal since the project is still MVP.