### PR TITLE
feat(agent): repair near-miss tool calls and size the prompt to the w…

### DIFF
--- a/src/agent/adapter.test.ts
+++ b/src/agent/adapter.test.ts
@@ -35,6 +35,34 @@ describe('parseTextToolCalls', () => {
     expect(calls[0].function.arguments).toEqual({ path: 'x' })
   })
 
+  it('resolves a mis-spelled tool name to the real one', () => {
+    const { calls } = parseTextToolCalls('{"name":"readFile","arguments":{"path":"a.ts"}}', KNOWN)
+    expect(calls[0].function.name).toBe('read_file')
+  })
+
+  it('resolves an alias borrowed from another harness', () => {
+    const { calls } = parseTextToolCalls('<tool_call>{"tool":"bash","args":{"command":"ls"}}</tool_call>', KNOWN)
+    expect(calls[0].function).toEqual({ name: 'run_bash', arguments: { command: 'ls' } })
+  })
+
+  it('pulls every bare JSON call, not just the first', () => {
+    const { calls, cleanedText } = parseTextToolCalls(
+      'reading both:\n{"name":"read_file","arguments":{"path":"a.ts"}}\n{"name":"read_file","arguments":{"path":"b.ts"}}',
+      KNOWN,
+    )
+    expect(calls.map((c) => c.function.arguments.path)).toEqual(['a.ts', 'b.ts'])
+    expect(cleanedText).toBe('reading both:')
+  })
+
+  it('keeps scanning past a JSON object that is not a call', () => {
+    const { calls, cleanedText } = parseTextToolCalls(
+      'config is {"debug":true} — now {"name":"read_file","arguments":{"path":"a.ts"}}',
+      KNOWN,
+    )
+    expect(calls).toHaveLength(1)
+    expect(cleanedText).toContain('{"debug":true}')
+  })
+
   it('rejects an object whose name is not a known tool', () => {
     const { calls, cleanedText } = parseTextToolCalls('{"name":"frobnicate","arguments":{}}', KNOWN)
     expect(calls).toHaveLength(0)

--- a/src/agent/adapter.ts
+++ b/src/agent/adapter.ts
@@ -1,4 +1,5 @@
 import type { OllamaMessage } from '../llm/types.js'
+import { resolveToolName } from './normalize.js'
 import type { MiiMessage, ContentBlock, ToolUse, ToolResultBlock } from './types.js'
 
 export function mintToolUseId(): string {
@@ -102,17 +103,45 @@ export function parseTextToolCalls(
     return _m
   })
 
-  if (calls.length === 0) {
-    const candidate = extractFirstJsonObject(cleaned)
-    if (candidate) {
-      const c = tryParse(candidate.json, knownToolNames)
-      if (c) {
-        calls.push(c)
-        cleaned = (cleaned.slice(0, candidate.start) + cleaned.slice(candidate.end)).trim()
-      }
-    }
+  // Bare JSON objects printed straight into the prose. Scan the whole string,
+  // not just the first object: a model that emits one call as text usually
+  // emits the rest the same way, and dropping the tail silently loses work.
+  const bare = parseBareJsonCalls(cleaned, knownToolNames)
+  if (bare.calls.length > 0) {
+    calls.push(...bare.calls)
+    cleaned = bare.cleanedText
   }
 
+  return { calls, cleanedText: cleaned.trim() }
+}
+
+/** Pull every balanced top-level JSON object that reads as a tool call. */
+function parseBareJsonCalls(
+  text: string,
+  knownToolNames: string[],
+): { calls: RawToolCall[]; cleanedText: string } {
+  const calls: RawToolCall[] = []
+  let cleaned = ''
+  let rest = text
+  let offset = 0
+
+  while (offset < rest.length) {
+    const candidate = extractFirstJsonObject(rest.slice(offset))
+    if (!candidate) break
+    const start = offset + candidate.start
+    const end = offset + candidate.end
+    const c = tryParse(candidate.json, knownToolNames)
+    if (c) {
+      calls.push(c)
+      cleaned += rest.slice(0, start)
+      rest = rest.slice(end)
+      offset = 0
+    } else {
+      // Not a call — keep it in the text and resume scanning after it.
+      offset = end
+    }
+  }
+  cleaned += rest
   return { calls, cleanedText: cleaned.trim() }
 }
 
@@ -121,9 +150,13 @@ function tryParse(raw: string, knownToolNames: string[]): RawToolCall | null {
   if (!s.startsWith('{')) return null
   try {
     const obj = JSON.parse(s) as Record<string, unknown>
-    const name = typeof obj.name === 'string' ? obj.name : undefined
-    const args = (obj.arguments ?? obj.parameters ?? obj.input ?? {}) as Record<string, unknown>
-    if (!name || !knownToolNames.includes(name)) return null
+    const rawName = typeof obj.name === 'string' ? obj.name : typeof obj.tool === 'string' ? obj.tool : undefined
+    const args = (obj.arguments ?? obj.parameters ?? obj.input ?? obj.args ?? {}) as Record<string, unknown>
+    if (!rawName) return null
+    // Strict resolution (no edit-distance guessing) — this text came out of
+    // prose, so a loose match could turn an ordinary sentence into a real call.
+    const name = resolveToolName(rawName, knownToolNames, false)
+    if (!name) return null
     return { function: { name, arguments: args } }
   } catch {
     return null
@@ -150,14 +183,14 @@ function parseCallSyntax(
   let lastEnd = 0
 
   while ((m = headRe.exec(text)) !== null) {
-    const name = m[1]
     const body = parseCallBody(text, m.index + m[0].length)
     if (!body) continue
     // Skip past the whole body before the next exec, even for unknown tools, so
     // a `call:...{...}` embedded in an unknown call's value isn't rescanned and
     // mistaken for a real call.
     headRe.lastIndex = body.end
-    if (!knownToolNames.includes(name)) continue
+    const name = resolveToolName(m[1], knownToolNames, false)
+    if (!name) continue
     calls.push({ function: { name, arguments: body.args } })
     cleaned += text.slice(lastEnd, m.index)
     lastEnd = body.end
@@ -264,11 +297,11 @@ export function looksLikeLeakedToolCall(text: string, knownToolNames: string[]):
   // `call:NAME{` — but only when NAME is an actual tool, so prose like
   // "I'll call: someone {" can't trip the nudge.
   const callMatch = text.match(/\bcall:\s*(\w+)\s*\{/)
-  if (callMatch && knownToolNames.includes(callMatch[1])) return true
+  if (callMatch && resolveToolName(callMatch[1], knownToolNames, false)) return true
   // JSON object literal that names a known tool with an args/params field.
   if (/"name"\s*:\s*"([^"]+)"/.test(text) && /"(arguments|parameters|input)"\s*:/.test(text)) {
     const name = text.match(/"name"\s*:\s*"([^"]+)"/)?.[1]
-    if (name && knownToolNames.includes(name)) return true
+    if (name && resolveToolName(name, knownToolNames, false)) return true
   }
   return false
 }

--- a/src/agent/loop.test.ts
+++ b/src/agent/loop.test.ts
@@ -14,6 +14,10 @@ const h = vi.hoisted(() => ({
   toolHandlers: {} as Record<string, (input: unknown) => unknown>,
   // permission decision for every call.
   decision: 'allow' as 'allow' | 'deny',
+  // How many times check() was consulted — proves we stop asking after a cancel.
+  checkCalls: 0,
+  // Runs inside check(); lets a test cancel the turn mid-permission-prompt.
+  onCheck: undefined as undefined | (() => void),
   // validateInput result: null = valid.
   validateResult: null as string | null,
 }))
@@ -68,7 +72,13 @@ vi.mock('../tools/validate.js', () => ({
 
 vi.mock('../prompt/system.js', () => ({ buildSystemPrompt: () => 'SYS' }))
 vi.mock('../prompt/context.js', () => ({ loadProjectContext: () => '' }))
-vi.mock('../permissions/policy.js', () => ({ check: async () => h.decision }))
+vi.mock('../permissions/policy.js', () => ({
+  check: async () => {
+    h.checkCalls++
+    h.onCheck?.()
+    return h.decision
+  },
+}))
 vi.mock('../config.js', () => ({
   loadConfig: () => ({ effort: 'medium' }),
   EFFORT_OPTIONS: { medium: { num_predict: -1, temperature: 0.5 } },
@@ -161,6 +171,8 @@ beforeEach(() => {
   h.alwaysTool = false
   h.toolHandlers = {}
   h.decision = 'allow'
+  h.checkCalls = 0
+  h.onCheck = undefined
   h.validateResult = null
 })
 
@@ -257,6 +269,71 @@ describe('runAgent abort', () => {
     const aborted = events.find((e) => e.type === 'aborted')!
     expect(aborted).toMatchObject({ type: 'aborted' })
     expect(typeof (aborted as { duration_ms: number }).duration_ms).toBe('number')
+  })
+
+  // Esc at a permission prompt cancels the turn. The remaining tools in that
+  // turn must not be prompted for or run — but each still needs a tool_result,
+  // or the persisted history ends on an unmatched tool_use and the next request
+  // breaks when the session resumes.
+  describe('cancelled at a permission prompt', () => {
+    const ac = { current: null as AbortController | null }
+
+    async function driveCancelledMidTurn() {
+      ac.current = new AbortController()
+      h.script = [toolThenDone([call('run_bash', { command: 'a' }), call('run_bash', { command: 'b' })])]
+      // The user hits Esc while the first prompt is up: the pending prompt
+      // resolves 'no' and the run is aborted.
+      h.decision = 'deny'
+      h.onCheck = () => ac.current!.abort()
+      return drive({ signal: ac.current.signal })
+    }
+
+    it('stops asking for permission once the turn is cancelled', async () => {
+      await driveCancelledMidTurn()
+      expect(h.checkCalls).toBe(1)
+    })
+
+    it('still emits one tool_result per tool_use', async () => {
+      const { history } = await driveCancelledMidTurn()
+      assertBlockOrdering(history)
+      const results = firstResults(history)
+      expect(results).toHaveLength(2)
+      expect(results.every((r) => r.is_error)).toBe(true)
+      expect(results[1].content).toMatch(/[Cc]ancelled/)
+    })
+
+    it('ends the run as aborted, not as a completed turn', async () => {
+      const { events } = await driveCancelledMidTurn()
+      const t = types(events)
+      expect(t).toContain('aborted')
+      expect(t).not.toContain('done')
+    })
+
+    // The other order: the cancel lands after the first tool was already
+    // approved and run. That one keeps its real result; the rest are skipped.
+    it('does not run the tools left after the cancel', async () => {
+      let ran = 0
+      ac.current = new AbortController()
+      h.script = [
+        toolThenDone([
+          call('run_bash', { command: 'a' }),
+          call('run_bash', { command: 'b' }),
+          call('run_bash', { command: 'c' }),
+        ]),
+      ]
+      h.decision = 'allow'
+      h.toolHandlers = { run_bash: () => { ran++; ac.current!.abort(); return { content: 'ran' } } }
+      const { history } = await drive({ signal: ac.current.signal })
+
+      expect(ran).toBe(1)
+      assertBlockOrdering(history)
+      const results = firstResults(history)
+      expect(results).toHaveLength(3)
+      expect(results[0]).toMatchObject({ content: 'ran' })
+      expect(results[0].is_error).toBeFalsy()
+      expect(results[1].content).toMatch(/[Cc]ancelled/)
+      expect(results[2].content).toMatch(/[Cc]ancelled/)
+    })
   })
 })
 
@@ -361,5 +438,34 @@ describe('runAgent leaked-tool-call nudge', () => {
     expect(events).toContainEqual({ type: 'turn-end', stop_reason: 'end_turn' })
     expect(t).toContain('done')
     expect(t).not.toContain('error')
+  })
+})
+
+describe('near-miss tool calls', () => {
+  it('runs a call whose tool name is mis-spelled, under the real name', async () => {
+    h.script = [toolThenDone([call('runBash', { command: 'ls' })]), textThenDone('done')]
+    const { events, history } = await drive()
+    const use = events.find((e) => e.type === 'tool-use') as { block: ToolUse }
+    expect(use.block.name).toBe('run_bash')
+    expect(firstResults(history)[0].is_error).toBeFalsy()
+  })
+
+  it('unwraps a call envelope before the tool sees it', async () => {
+    let seen: unknown
+    h.toolHandlers.run_bash = (input) => { seen = input; return { content: 'ok' } }
+    h.script = [
+      toolThenDone([call('run_bash', { name: 'run_bash', arguments: { command: 'ls' } })]),
+      textThenDone('done'),
+    ]
+    await drive()
+    expect(seen).toEqual({ command: 'ls' })
+  })
+
+  it('still reports a name that resolves to nothing', async () => {
+    h.script = [toolThenDone([call('frobnicate', {})]), textThenDone('done')]
+    const { history } = await drive()
+    const r = firstResults(history)[0]
+    expect(r.is_error).toBe(true)
+    expect(r.content).toContain('Unknown tool')
   })
 })

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -13,6 +13,7 @@ import {
   blocksFromOllama,
   looksLikeLeakedToolCall,
 } from './adapter.js'
+import { resolveToolName, normalizeToolInput } from './normalize.js'
 import type {
   MiiMessage,
   AgentEvent,
@@ -53,21 +54,24 @@ function readGuard(name: string, input: unknown, seen: Set<string>): string | nu
 }
 
 /**
- * Some local models echo the full call envelope as the tool input, e.g.
- *   { name: "write_file", arguments: { path, content } }
- * instead of the bare { path, content }. Unwrap to the inner arguments so
- * validation/handlers see the real fields — otherwise the model loops,
- * re-emitting the same malformed call until the repeat-kill fires.
+ * Repair a turn's tool calls in place, before anything else looks at them.
+ *
+ * A small model usually gets the intent right and the spelling wrong: it calls
+ * `readFile`, passes `file_path`, sends `"20"` where a number is declared, or
+ * wraps the arguments in a `{name, arguments}` envelope. Left alone each of
+ * those burns a full round trip — a rejected call, an error, a retry — which on
+ * a small context window is the difference between finishing and running out of
+ * room. Repairing here means the corrected call is what the UI shows, what
+ * loop-detection compares, and what gets persisted to history, so the model
+ * never re-reads its own mistake and learns it back.
  */
-function unwrapEnvelope(name: string, input: Record<string, unknown>): Record<string, unknown> {
-  if (!('arguments' in input)) return input
-  if ('name' in input && input.name !== name) return input
-  let args = input.arguments
-  if (typeof args === 'string') {
-    try { args = JSON.parse(args) } catch { return input }
+function repairToolUses(tool_uses: ToolUse[], toolNames: string[]): void {
+  for (const use of tool_uses) {
+    const resolved = resolveToolName(use.name, toolNames)
+    if (resolved) use.name = resolved
+    const tool = getTool(use.name)
+    if (tool) use.input = normalizeToolInput(tool.input_schema, use.input).input
   }
-  if (args && typeof args === 'object' && !Array.isArray(args)) return args as Record<string, unknown>
-  return input
 }
 
 // Tools whose payload carries a large free-text field (file body / edit text).
@@ -140,7 +144,6 @@ export interface RunAgentOpts {
 export async function* runAgent(opts: RunAgentOpts): AsyncGenerator<AgentEvent, MiiMessage[]> {
   const { model, cwd, permissions, hooks, signal, num_ctx } = opts
   const startTime = Date.now()
-  const system = buildSystemPrompt(TOOLS, cwd, loadProjectContext(cwd))
   const ollamaTools = toOllamaTools(TOOLS)
   const toolNames = TOOLS.map((t) => t.name)
   const cfg = loadConfig()
@@ -153,6 +156,9 @@ export async function* runAgent(opts: RunAgentOpts): AsyncGenerator<AgentEvent, 
   const ctxCap = cfg.numCtxCap && cfg.numCtxCap > 0 ? cfg.numCtxCap : DEFAULT_NUM_CTX_CAP
   const cappedCtx =
     typeof num_ctx === 'number' && num_ctx > 0 ? Math.min(num_ctx, ctxCap) : undefined
+  // Built after cappedCtx: the prompt sizes itself to the window we actually
+  // negotiated, dropping its optional layer when there is no room to spare.
+  const system = buildSystemPrompt(TOOLS, cwd, loadProjectContext(cwd), cappedCtx)
 
   const history: MiiMessage[] = [
     ...opts.history,
@@ -260,6 +266,11 @@ export async function* runAgent(opts: RunAgentOpts): AsyncGenerator<AgentEvent, 
     const blocks: ContentBlock[] = blocksFromOllama(text, tool_calls, toolNames)
     const tool_uses = blocks.filter((b): b is ToolUse => b.type === 'tool_use')
 
+    // Repair names/arguments before anything downstream reads them — the blocks
+    // are mutated in place, so history, the UI and loop-detection all see the
+    // corrected call rather than the model's near-miss.
+    repairToolUses(tool_uses, toolNames)
+
     // Loop detection runs BEFORE the assistant message is committed to history.
     // If we push first and then bail on a detected repeat, the persisted history
     // ends on an assistant tool_use with no matching tool_result — which breaks
@@ -361,7 +372,7 @@ export async function* runAgent(opts: RunAgentOpts): AsyncGenerator<AgentEvent, 
         const r: ToolResultBlock = {
           type: 'tool_result',
           tool_use_id: use.id,
-          content: `Unknown tool: ${use.name}. There's no tool by that name — check the spelling against the tools you were given.`,
+          content: `Unknown tool: ${use.name}. There's no tool by that name. Available tools: ${toolNames.join(', ')}. Pick the one that does what you meant and call it by its exact name.`,
           is_error: true,
         }
         results.push(r)
@@ -369,7 +380,22 @@ export async function* runAgent(opts: RunAgentOpts): AsyncGenerator<AgentEvent, 
         continue
       }
 
-      use.input = unwrapEnvelope(use.name, use.input)
+      // Cancelled mid-turn (Esc). Don't prompt for or run what's left — but do
+      // emit a tool_result for every tool_use, or the persisted history ends on
+      // an unmatched tool_use and breaks the next request when the session
+      // resumes. Same invariant the truncation path above protects.
+      if (signal?.aborted) {
+        const r: ToolResultBlock = {
+          type: 'tool_result',
+          tool_use_id: use.id,
+          content: `Cancelled — the user stopped the turn before ${use.name} ran.`,
+          is_error: true,
+        }
+        results.push(r)
+        yield { type: 'tool-result', block: r }
+        continue
+      }
+
       const invalid = validateInput(tool.input_schema, use.input)
       if (invalid) {
         // Empty/garbled args on a big-write tool almost always means a

--- a/src/agent/normalize.test.ts
+++ b/src/agent/normalize.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect } from 'vitest'
+import { resolveToolName, unwrapEnvelope, repairJson, normalizeToolInput } from './normalize.js'
+import { getTool, TOOLS } from '../tools/registry.js'
+
+const NAMES = TOOLS.map((t) => t.name)
+const schema = (name: string) => getTool(name)!.input_schema
+
+describe('resolveToolName', () => {
+  it('passes an exact name straight through', () => {
+    expect(resolveToolName('read_file', NAMES)).toBe('read_file')
+  })
+
+  it('normalises casing and separators', () => {
+    for (const raw of ['readFile', 'ReadFile', 'read-file', 'READ_FILE', 'read file']) {
+      expect(resolveToolName(raw, NAMES)).toBe('read_file')
+    }
+  })
+
+  it('strips a namespace prefix', () => {
+    expect(resolveToolName('functions.run_bash', NAMES)).toBe('run_bash')
+    expect(resolveToolName('tools/write_file', NAMES)).toBe('write_file')
+  })
+
+  it('maps names borrowed from other harnesses', () => {
+    expect(resolveToolName('bash', NAMES)).toBe('run_bash')
+    expect(resolveToolName('str_replace_editor', NAMES)).toBe('edit_file')
+    expect(resolveToolName('ripgrep', NAMES)).toBe('grep')
+    expect(resolveToolName('TodoWrite', NAMES)).toBe('write_todos')
+    expect(resolveToolName('list_files', NAMES)).toBe('glob')
+  })
+
+  it('recovers a typo via edit distance', () => {
+    expect(resolveToolName('read_fil', NAMES)).toBe('read_file')
+    expect(resolveToolName('wrote_file', NAMES)).toBe('write_file')
+  })
+
+  it('refuses a name that is nothing like a tool', () => {
+    expect(resolveToolName('frobnicate', NAMES)).toBeNull()
+    expect(resolveToolName('', NAMES)).toBeNull()
+  })
+
+  it('does not guess when fuzzy matching is off', () => {
+    expect(resolveToolName('read_fil', NAMES, false)).toBeNull()
+    // Exact, canonical and alias tiers still apply.
+    expect(resolveToolName('readFile', NAMES, false)).toBe('read_file')
+    expect(resolveToolName('bash', NAMES, false)).toBe('run_bash')
+  })
+
+  it('stays silent on an ambiguous tie', () => {
+    // Equidistant from both — better to report unknown than to pick one.
+    expect(resolveToolName('ile', ['file_a', 'file_b'])).toBeNull()
+  })
+})
+
+describe('repairJson', () => {
+  it('returns valid JSON unchanged', () => {
+    expect(repairJson('{"a":1}')).toEqual({ a: 1 })
+  })
+
+  it('closes a string and braces cut off mid-write', () => {
+    expect(repairJson('{"path":"a.ts","content":"const x = 1')).toEqual({
+      path: 'a.ts',
+      content: 'const x = 1',
+    })
+  })
+
+  it('drops a key the model never got to fill', () => {
+    expect(repairJson('{"path":"a.ts","content":')).toEqual({ path: 'a.ts' })
+    expect(repairJson('{"path":"a.ts",')).toEqual({ path: 'a.ts' })
+  })
+
+  it('closes nested structures', () => {
+    expect(repairJson('{"todos":[{"content":"do it","status":"pend')).toEqual({
+      todos: [{ content: 'do it', status: 'pend' }],
+    })
+  })
+
+  it('rejects something that is not an object', () => {
+    expect(repairJson('just prose')).toBeNull()
+    expect(repairJson('[1,2]')).toBeNull()
+  })
+})
+
+describe('unwrapEnvelope', () => {
+  it('unwraps {name, arguments}', () => {
+    expect(unwrapEnvelope({ name: 'write_file', arguments: { path: 'a', content: 'b' } }))
+      .toEqual({ path: 'a', content: 'b' })
+  })
+
+  it('unwraps the args/parameters/input spellings', () => {
+    expect(unwrapEnvelope({ tool: 'grep', args: { pattern: 'x' } })).toEqual({ pattern: 'x' })
+    expect(unwrapEnvelope({ name: 'grep', parameters: { pattern: 'x' } })).toEqual({ pattern: 'x' })
+    expect(unwrapEnvelope({ name: 'grep', input: { pattern: 'x' } })).toEqual({ pattern: 'x' })
+  })
+
+  it('unwraps a nested function envelope', () => {
+    expect(unwrapEnvelope({ function: { name: 'read_file', arguments: { path: 'a' } } }))
+      .toEqual({ path: 'a' })
+  })
+
+  it('parses arguments handed over as a JSON string', () => {
+    expect(unwrapEnvelope({ name: 'read_file', arguments: '{"path":"a.ts"}' }))
+      .toEqual({ path: 'a.ts' })
+  })
+
+  it('recovers the _raw fallback the OpenAI adapter leaves behind', () => {
+    expect(unwrapEnvelope({ _raw: '{"path":"a.ts","offset":2' }))
+      .toEqual({ path: 'a.ts', offset: 2 })
+  })
+
+  it('leaves a real payload alone', () => {
+    const real = { path: 'a.ts', content: 'x' }
+    expect(unwrapEnvelope(real)).toBe(real)
+  })
+
+  it('leaves a payload that merely has extra fields beside arguments', () => {
+    // `path` is not envelope machinery, so this is a real payload with a stray
+    // key — descending would throw away the path the model actually gave.
+    const input = { path: 'a.ts', arguments: { path: 'b.ts' } }
+    expect(unwrapEnvelope(input)).toBe(input)
+  })
+})
+
+describe('normalizeToolInput', () => {
+  it('renames keys borrowed from other harnesses', () => {
+    const { input, repairs } = normalizeToolInput(schema('read_file'), { file_path: 'a.ts' })
+    expect(input).toEqual({ path: 'a.ts' })
+    expect(repairs).toContain('file_path → path')
+  })
+
+  it('renames per tool, without cross-tool confusion', () => {
+    // `limit` means max_results to grep, and is a declared field of read_file.
+    expect(normalizeToolInput(schema('grep'), { pattern: 'x', limit: 5 }).input)
+      .toEqual({ pattern: 'x', max_results: 5 })
+    expect(normalizeToolInput(schema('read_file'), { path: 'a', limit: 5 }).input)
+      .toEqual({ path: 'a', limit: 5 })
+  })
+
+  it('never remaps a spelling the tool itself declares', () => {
+    // grep declares both `glob` and `pattern`; `glob` must stay put.
+    expect(normalizeToolInput(schema('grep'), { pattern: 'x', glob: '*.ts' }).input)
+      .toEqual({ pattern: 'x', glob: '*.ts' })
+  })
+
+  it('never overwrites a field the model already set', () => {
+    const { input } = normalizeToolInput(schema('read_file'), { path: 'real.ts', filename: 'other.ts' })
+    expect(input.path).toBe('real.ts')
+    expect(input.filename).toBe('other.ts')
+  })
+
+  it('coerces stringified numbers and booleans', () => {
+    const { input } = normalizeToolInput(schema('grep'), {
+      pattern: 'x', max_results: '20', case_insensitive: 'true', files_only: 'no',
+    })
+    expect(input).toEqual({
+      pattern: 'x', max_results: 20, case_insensitive: true, files_only: false,
+    })
+  })
+
+  it('joins file content sent as an array of lines', () => {
+    const { input } = normalizeToolInput(schema('write_file'), {
+      path: 'a.ts', content: ['const a = 1', 'const b = 2'],
+    })
+    expect(input.content).toBe('const a = 1\nconst b = 2')
+  })
+
+  it('parses an array field sent as a JSON string', () => {
+    const { input } = normalizeToolInput(schema('write_todos'), {
+      todos: '[{"content":"ship it","status":"pending"}]',
+    })
+    expect(input.todos).toEqual([{ content: 'ship it', status: 'pending' }])
+  })
+
+  it('wraps a single item where a list is declared, and fixes its keys', () => {
+    const { input } = normalizeToolInput(schema('write_todos'), {
+      tasks: { task: 'ship it', state: 'pending' },
+    })
+    expect(input.todos).toEqual([{ content: 'ship it', status: 'pending' }])
+  })
+
+  it('fixes keys inside array items', () => {
+    const { input } = normalizeToolInput(schema('edit_file'), {
+      path: 'a.ts',
+      edits: [{ old_string: 'a', new_string: 'b' }],
+    })
+    expect(input.edits).toEqual([{ old_str: 'a', new_str: 'b' }])
+  })
+
+  it('handles an envelope, a rename and a coercion in one call', () => {
+    const { input } = normalizeToolInput(schema('read_file'), {
+      name: 'read_file',
+      arguments: '{"file_path":"a.ts","start_line":"10"}',
+    })
+    expect(input).toEqual({ path: 'a.ts', offset: 10 })
+  })
+
+  it('leaves a well-formed call completely untouched', () => {
+    const clean = { path: 'a.ts', old_str: 'a', new_str: 'b', replace_all: true }
+    const { input, repairs } = normalizeToolInput(schema('edit_file'), clean)
+    expect(input).toEqual(clean)
+    expect(repairs).toEqual([])
+  })
+
+  it('leaves an unsalvageable value for validation to reject', () => {
+    const { input } = normalizeToolInput(schema('read_file'), { path: 'a.ts', offset: 'soon' })
+    expect(input.offset).toBe('soon')
+  })
+})
+
+describe('lone-argument adoption', () => {
+  it('adopts the only leftover key for the only unfilled required field', () => {
+    const { input, repairs } = normalizeToolInput(schema('run_bash'), { instruction: 'ls -la' })
+    expect(input).toEqual({ command: 'ls -la' })
+    expect(repairs.join()).toContain('only field left unfilled')
+  })
+
+  it('stays out of it when more than one field is missing', () => {
+    const { input } = normalizeToolInput(schema('write_file'), { whatever: 'x' })
+    expect(input).toEqual({ whatever: 'x' })
+  })
+
+  it('stays out of it when more than one key is unrecognised', () => {
+    const { input } = normalizeToolInput(schema('run_bash'), { foo: 'ls', bar: 'pwd' })
+    expect(input).toEqual({ foo: 'ls', bar: 'pwd' })
+  })
+
+  it('stays out of it when the type is wrong', () => {
+    const { input } = normalizeToolInput(schema('run_bash'), { foo: 42 })
+    expect(input).toEqual({ foo: 42 })
+  })
+
+  it('stays out of it when the required field is already filled', () => {
+    const { input } = normalizeToolInput(schema('run_bash'), { command: 'ls', note: 'hi' })
+    expect(input).toEqual({ command: 'ls', note: 'hi' })
+  })
+})

--- a/src/agent/normalize.ts
+++ b/src/agent/normalize.ts
@@ -1,0 +1,486 @@
+import type { JsonSchema, PropSpec } from '../tools/types.js'
+
+/**
+ * Tool-call comprehension layer.
+ *
+ * Small local models get the *intent* of a tool call right far more often than
+ * they get its *spelling* right: they call `readFile` instead of `read_file`,
+ * pass `file_path` instead of `path`, send `"10"` where a number is declared,
+ * or wrap the whole call in an envelope. Every one of those costs a full round
+ * trip — a rejected call, an error message, a retry — which on a 4k–8k context
+ * is the difference between finishing the task and running out of room.
+ *
+ * So instead of rejecting a near-miss and spending a turn teaching the model to
+ * spell, we repair what is unambiguous here and run the call. Repairs are
+ * deliberately conservative: a rename only happens when the target field is
+ * declared by the schema AND absent, so a repair can never overwrite something
+ * the model actually said.
+ */
+
+// ---------------------------------------------------------------------------
+// Tool name resolution
+// ---------------------------------------------------------------------------
+
+/** Lowercase, strip any namespace prefix and every non-alphanumeric character. */
+function canon(s: string): string {
+  return s
+    .trim()
+    .replace(/^(functions?|tools?|namespace)[.:/]/i, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, '')
+}
+
+/**
+ * Canonical-form aliases → miii tool name. These are the names other agent
+ * harnesses use (Claude Code, Cursor, Aider, OpenAI function samples); a model
+ * trained on those transcripts reaches for them by reflex.
+ */
+const NAME_ALIASES: Record<string, string> = {
+  // run_bash
+  bash: 'run_bash', sh: 'run_bash', shell: 'run_bash', exec: 'run_bash',
+  execute: 'run_bash', executecommand: 'run_bash', runcommand: 'run_bash',
+  runshell: 'run_bash', runterminalcmd: 'run_bash', terminal: 'run_bash',
+  command: 'run_bash', cmd: 'run_bash', shellexec: 'run_bash',
+  // read_file
+  read: 'read_file', cat: 'read_file', view: 'read_file', viewfile: 'read_file',
+  openfile: 'read_file', getfile: 'read_file', filecontents: 'read_file',
+  readfilecontents: 'read_file', showfile: 'read_file',
+  // write_file
+  write: 'write_file', create: 'write_file', createfile: 'write_file',
+  savefile: 'write_file', newfile: 'write_file', putfile: 'write_file',
+  filewrite: 'write_file', writetofile: 'write_file',
+  // edit_file
+  edit: 'edit_file', patch: 'edit_file', applypatch: 'edit_file',
+  applydiff: 'edit_file', strreplace: 'edit_file', strreplaceeditor: 'edit_file',
+  replaceinfile: 'edit_file', modifyfile: 'edit_file', updatefile: 'edit_file',
+  searchreplace: 'edit_file',
+  // grep
+  search: 'grep', searchfiles: 'grep', searchtext: 'grep', ripgrep: 'grep',
+  rg: 'grep', findinfiles: 'grep', codesearch: 'grep', grepsearch: 'grep',
+  // glob
+  find: 'glob', findfiles: 'glob', listfiles: 'glob', ls: 'glob',
+  listdir: 'glob', listdirectory: 'glob', filesearch: 'glob', globsearch: 'glob',
+  // write_todos
+  todo: 'write_todos', todos: 'write_todos', todowrite: 'write_todos',
+  writetodo: 'write_todos', settodos: 'write_todos', updatetodos: 'write_todos',
+  tasklist: 'write_todos', updatetasklist: 'write_todos',
+}
+
+/** Levenshtein distance, capped — we only ever care about "is it ≤ 2". */
+function distance(a: string, b: string): number {
+  if (Math.abs(a.length - b.length) > 2) return 99
+  let prev = Array.from({ length: b.length + 1 }, (_, i) => i)
+  for (let i = 1; i <= a.length; i++) {
+    const cur = [i]
+    for (let j = 1; j <= b.length; j++) {
+      cur[j] = Math.min(
+        prev[j] + 1,
+        cur[j - 1] + 1,
+        prev[j - 1] + (a[i - 1] === b[j - 1] ? 0 : 1),
+      )
+    }
+    prev = cur
+  }
+  return prev[b.length]
+}
+
+/**
+ * Map whatever the model called the tool onto a real tool name, or null if it
+ * plainly meant something else.
+ *
+ * Tiers, most to least certain: exact → canonical form (case/underscore/dot
+ * noise) → known alias from another harness → nearest name within edit distance
+ * 2, and only when exactly one candidate is that close.
+ *
+ * `fuzzy` gates that last tier. It is on for structured tool calls, where the
+ * model has unmistakably committed to calling *a* tool and the only question is
+ * which. It is off when we are salvaging a call out of prose, where a loose
+ * match could turn an ordinary sentence into a filesystem write.
+ */
+export function resolveToolName(
+  raw: string,
+  known: string[],
+  fuzzy = true,
+): string | null {
+  if (!raw) return null
+  if (known.includes(raw)) return raw
+
+  const c = canon(raw)
+  if (!c) return null
+
+  for (const name of known) if (canon(name) === c) return name
+
+  const alias = NAME_ALIASES[c]
+  if (alias && known.includes(alias)) return alias
+
+  if (!fuzzy) return null
+
+  let best: string | null = null
+  let bestScore = 3
+  let tied = false
+  for (const name of known) {
+    const d = distance(c, canon(name))
+    if (d < bestScore) { bestScore = d; best = name; tied = false }
+    else if (d === bestScore) tied = true
+  }
+  return tied ? null : best
+}
+
+// ---------------------------------------------------------------------------
+// Envelope unwrapping
+// ---------------------------------------------------------------------------
+
+const ENVELOPE_KEYS = new Set([
+  'name', 'tool', 'tool_name', 'toolname', 'function', 'recipient_name',
+])
+const ARG_KEYS = ['arguments', 'args', 'parameters', 'params', 'input', 'tool_input']
+
+/**
+ * Best-effort close of a JSON document that was cut off mid-write: terminate an
+ * open string, drop a dangling key or comma, then close every open bracket.
+ * Recovers the fields that *did* arrive from a response that hit the token cap.
+ */
+export function repairJson(raw: string): Record<string, unknown> | null {
+  const s = raw.trim()
+  if (!s.startsWith('{')) return null
+  try { return JSON.parse(s) as Record<string, unknown> } catch { /* fall through */ }
+
+  const stack: string[] = []
+  let inStr = false
+  let esc = false
+  for (const ch of s) {
+    if (inStr) {
+      if (esc) esc = false
+      else if (ch === '\\') esc = true
+      else if (ch === '"') inStr = false
+      continue
+    }
+    if (ch === '"') inStr = true
+    else if (ch === '{') stack.push('}')
+    else if (ch === '[') stack.push(']')
+    else if (ch === '}' || ch === ']') stack.pop()
+  }
+
+  let body = s
+  // An escape half-written at the cut point would make the closing quote escape
+  // itself, so drop it before terminating the string.
+  if (esc) body = body.slice(0, -1)
+  if (inStr) body += '"'
+  // Trailing `, "key":` or `,` — a field the model never got to finish.
+  body = body.replace(/,\s*"[^"]*"\s*:?\s*$/, '').replace(/,\s*$/, '')
+  body += stack.reverse().join('')
+
+  try {
+    const parsed = JSON.parse(body) as unknown
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : null
+  } catch {
+    return null
+  }
+}
+
+function asObject(v: unknown): Record<string, unknown> | null {
+  if (typeof v === 'string') return repairJson(v)
+  if (v && typeof v === 'object' && !Array.isArray(v)) return v as Record<string, unknown>
+  return null
+}
+
+/**
+ * Peel the call envelope some models emit in place of bare arguments —
+ * `{name, arguments}`, `{tool, args}`, `{function: {name, arguments}}`, or an
+ * `arguments` field that is itself a JSON string. Also recovers `_raw`, which
+ * is what the OpenAI adapter stores when streamed argument JSON fails to parse.
+ *
+ * Bails the moment the object carries a key that isn't envelope machinery, so a
+ * genuine payload that happens to have a `name` field is left alone.
+ */
+export function unwrapEnvelope(input: Record<string, unknown>): Record<string, unknown> {
+  let cur = input
+  for (let depth = 0; depth < 4; depth++) {
+    if (typeof cur._raw === 'string' && Object.keys(cur).length === 1) {
+      const repaired = repairJson(cur._raw)
+      if (!repaired) return cur
+      cur = repaired
+      continue
+    }
+
+    const fn = asObject(cur.function)
+    if (fn && Object.keys(cur).every((k) => ENVELOPE_KEYS.has(k))) {
+      cur = fn
+      continue
+    }
+
+    const argKey = ARG_KEYS.find((k) => k in cur)
+    if (!argKey) return cur
+    // Every other key must be envelope machinery, or this is a real payload
+    // that merely happens to declare an `input`/`args` field of its own.
+    if (!Object.keys(cur).every((k) => k === argKey || ENVELOPE_KEYS.has(k))) return cur
+    const inner = asObject(cur[argKey])
+    if (!inner) return cur
+    cur = inner
+  }
+  return cur
+}
+
+// ---------------------------------------------------------------------------
+// Argument key aliasing
+// ---------------------------------------------------------------------------
+
+/**
+ * Canonical field name → the spellings models reach for instead, in canonical
+ * form. An entry only ever applies when the tool actually declares that field
+ * and the model didn't already fill it, so overlapping names across tools
+ * (grep's `max_results` vs read_file's `limit`) resolve per-schema on their own.
+ */
+const KEY_ALIASES: Record<string, string[]> = {
+  path: ['filepath', 'file', 'filename', 'targetfile', 'fname', 'src', 'source', 'directory', 'dir', 'rootpath', 'root', 'location'],
+  content: ['contents', 'text', 'data', 'body', 'filecontent', 'filecontents', 'newcontent', 'code', 'value', 'task', 'title', 'label', 'step', 'item', 'todo', 'description'],
+  command: ['cmd', 'shellcommand', 'bashcommand', 'script', 'commandline', 'run', 'commandtorun'],
+  pattern: ['query', 'regex', 'regexp', 'searchpattern', 'searchstring', 'expression', 'globpattern', 'term', 'keyword', 'q', 'search', 'filepattern'],
+  old_str: ['oldstring', 'old', 'oldtext', 'searchtext', 'find', 'from', 'original', 'target', 'oldcontent'],
+  new_str: ['newstring', 'new', 'newtext', 'replace', 'replacement', 'to', 'replacewith', 'newcontent'],
+  replace_all: ['all', 'global', 'replaceevery', 'alloccurrences'],
+  edits: ['changes', 'replacements', 'patches', 'diffs'],
+  offset: ['start', 'startline', 'fromline', 'begin', 'linestart', 'skip'],
+  limit: ['numlines', 'linecount', 'maxlines', 'nlines', 'head', 'count'],
+  max_results: ['maxmatches', 'maxcount', 'headlimit', 'max', 'limit', 'topk'],
+  case_insensitive: ['ignorecase', 'caseinsensitivesearch', 'nocase', 'i'],
+  files_only: ['fileswithmatches', 'filenamesonly', 'listfiles', 'namesonly', 'l'],
+  fixed_strings: ['literal', 'fixed', 'plaintext', 'nonregex', 'f'],
+  multiline: ['multi', 'dotall', 'spanlines'],
+  context: ['contextlines', 'around', 'nearby', 'c'],
+  glob: ['fileglob', 'include', 'filefilter', 'filesglob'],
+  type: ['filetype', 'lang', 'language', 'ext'],
+  todos: ['tasks', 'items', 'todolist', 'tasklist', 'list', 'plan'],
+  status: ['state'],
+  timeout_ms: ['timeout', 'timeoutms', 'maxtime'],
+}
+
+/** Build canonical-alias → field lookup for one property set. */
+function aliasLookup(props: Record<string, PropSpec>): Map<string, string> {
+  const declared = new Set(Object.keys(props).map(canon))
+  const map = new Map<string, string>()
+  for (const [field, aliases] of Object.entries(KEY_ALIASES)) {
+    if (!(field in props)) continue
+    for (const a of aliases) {
+      // A spelling that is itself a declared field of this tool means what it
+      // says (grep declares both `glob` and `pattern`) — never remap it.
+      if (declared.has(a)) continue
+      if (!map.has(a)) map.set(a, field)
+    }
+  }
+  return map
+}
+
+/**
+ * Rename near-miss keys onto the fields the schema declares. Runs the alias
+ * table first, then falls back to edit distance for typos and casing variants
+ * the table doesn't list. Never clobbers a field the model already set, and
+ * leaves genuinely unrecognised keys in place — validation is permissive about
+ * extras, and a stray key is far cheaper than a wrong rename.
+ */
+function alignKeys(
+  props: Record<string, PropSpec>,
+  input: Record<string, unknown>,
+  repairs: string[],
+): Record<string, unknown> {
+  const lookup = aliasLookup(props)
+  const out: Record<string, unknown> = {}
+  const declared = Object.keys(props)
+
+  for (const [key, value] of Object.entries(input)) {
+    if (key in props) { out[key] = value; continue }
+
+    const c = canon(key)
+    let target = declared.find((d) => canon(d) === c) ?? lookup.get(c)
+
+    if (!target) {
+      let best: string | null = null
+      let bestScore = 3
+      let tied = false
+      for (const d of declared) {
+        const dist = distance(c, canon(d))
+        if (dist < bestScore) { bestScore = dist; best = d; tied = false }
+        else if (dist === bestScore) tied = true
+      }
+      if (best && !tied) target = best
+    }
+
+    if (target && target !== key && !(target in out) && !(target in input)) {
+      out[target] = value
+      repairs.push(`${key} → ${target}`)
+    } else {
+      out[key] = value
+    }
+  }
+  return out
+}
+
+// ---------------------------------------------------------------------------
+// Type coercion
+// ---------------------------------------------------------------------------
+
+const TRUE_WORDS = new Set(['true', 'yes', 'y', 'on', '1'])
+const FALSE_WORDS = new Set(['false', 'no', 'n', 'off', '0'])
+
+/**
+ * Coerce a value to the type the schema declares, when the model's intent is
+ * unambiguous — JSON handed over as a string, `"12"` for a number, `"true"` for
+ * a boolean, a bare item where a list is expected, a list of lines where a
+ * string is expected. Anything ambiguous is returned untouched for validation
+ * to reject properly.
+ */
+function coerce(spec: PropSpec, value: unknown, path: string, repairs: string[]): unknown {
+  if (value === null || value === undefined) return value
+  const note = (what: string) => repairs.push(`${path}: ${what}`)
+
+  switch (spec.type) {
+    case 'string': {
+      if (typeof value === 'string') return value
+      if (typeof value === 'number' || typeof value === 'boolean') {
+        note('stringified')
+        return String(value)
+      }
+      // A file body handed over as an array of lines — join it rather than
+      // failing the call and making the model resend the whole thing.
+      if (Array.isArray(value) && value.every((v) => typeof v === 'string')) {
+        note('joined lines')
+        return value.join('\n')
+      }
+      if (typeof value === 'object') {
+        note('serialised object')
+        return JSON.stringify(value, null, 2)
+      }
+      return value
+    }
+    case 'number':
+    case 'integer': {
+      if (typeof value === 'number') return value
+      if (typeof value === 'string' && value.trim() !== '' && Number.isFinite(Number(value))) {
+        note('parsed number')
+        return Number(value)
+      }
+      return value
+    }
+    case 'boolean': {
+      if (typeof value === 'boolean') return value
+      if (typeof value === 'number' && (value === 0 || value === 1)) {
+        note('parsed boolean')
+        return value === 1
+      }
+      if (typeof value === 'string') {
+        const v = value.trim().toLowerCase()
+        if (TRUE_WORDS.has(v)) { note('parsed boolean'); return true }
+        if (FALSE_WORDS.has(v)) { note('parsed boolean'); return false }
+      }
+      return value
+    }
+    case 'array': {
+      let arr = value
+      if (typeof arr === 'string') {
+        try {
+          const parsed = JSON.parse(arr)
+          if (Array.isArray(parsed)) { note('parsed JSON array'); arr = parsed }
+        } catch { /* not JSON — fall through to the wrap below */ }
+      }
+      if (!Array.isArray(arr)) {
+        // A single edit / single todo sent bare instead of in a list.
+        if (typeof arr === 'object' || typeof arr === 'string') { note('wrapped in array'); arr = [arr] }
+        else return arr
+      }
+      const items = spec.items
+      if (!items?.properties) return arr
+      return (arr as unknown[]).map((el, i) => {
+        const obj = asObject(el)
+        if (!obj) return el
+        return normalizeAgainst(
+          { type: 'object', properties: items.properties!, required: items.required },
+          obj,
+          `${path}[${i}]`,
+          repairs,
+        )
+      })
+    }
+    case 'object': {
+      if (typeof value === 'string') {
+        const parsed = repairJson(value)
+        if (parsed) { note('parsed JSON object'); return parsed }
+      }
+      return value
+    }
+    default:
+      return value
+  }
+}
+
+/**
+ * Last resort, after aliasing and typo-matching have both come up empty: the
+ * call is missing exactly one required field and carries exactly one key the
+ * schema doesn't recognise, whose value is already the right type. There is
+ * only one thing the model can have meant — a tiny model inventing its own name
+ * for the single argument the tool takes — so adopt it rather than spending a
+ * turn asking. Any ambiguity (two missing, two leftovers, wrong type) and this
+ * does nothing.
+ */
+function adoptLoneArgument(
+  schema: JsonSchema,
+  obj: Record<string, unknown>,
+  repairs: string[],
+): void {
+  const missing = (schema.required ?? []).filter((k) => obj[k] === undefined)
+  const leftover = Object.keys(obj).filter((k) => !(k in schema.properties))
+  if (missing.length !== 1 || leftover.length !== 1) return
+
+  const spec = schema.properties[missing[0]]
+  const value = obj[leftover[0]]
+  if (!spec) return
+  const ok =
+    spec.type === 'string' ? typeof value === 'string'
+      : spec.type === 'number' || spec.type === 'integer' ? typeof value === 'number'
+        : spec.type === 'boolean' ? typeof value === 'boolean'
+          : spec.type === 'array' ? Array.isArray(value)
+            : false
+  if (!ok) return
+
+  obj[missing[0]] = value
+  delete obj[leftover[0]]
+  repairs.push(`${leftover[0]} → ${missing[0]} (only field left unfilled)`)
+}
+
+function normalizeAgainst(
+  schema: JsonSchema,
+  input: Record<string, unknown>,
+  prefix: string,
+  repairs: string[],
+): Record<string, unknown> {
+  const aligned = alignKeys(schema.properties, input, repairs)
+  const out: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(aligned)) {
+    const spec = schema.properties[key]
+    out[key] = spec ? coerce(spec, value, prefix ? `${prefix}.${key}` : key, repairs) : value
+  }
+  adoptLoneArgument(schema, out, repairs)
+  return out
+}
+
+export interface Normalized {
+  input: Record<string, unknown>
+  /** Human-readable list of what was repaired; empty when the call arrived clean. */
+  repairs: string[]
+}
+
+/**
+ * Full repair pass for one tool call's arguments: unwrap any envelope, rename
+ * near-miss keys onto declared fields, then coerce each value to its declared
+ * type. Purely additive — a call that was already well-formed comes back
+ * unchanged with no repairs listed.
+ */
+export function normalizeToolInput(schema: JsonSchema, input: unknown): Normalized {
+  const repairs: string[] = []
+  const obj = asObject(input)
+  if (!obj) return { input: (input ?? {}) as Record<string, unknown>, repairs }
+  const unwrapped = unwrapEnvelope(obj)
+  if (unwrapped !== obj) repairs.push('unwrapped call envelope')
+  return { input: normalizeAgainst(schema, unwrapped, '', repairs), repairs }
+}

--- a/src/prompt/system.test.ts
+++ b/src/prompt/system.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from 'vitest'
+import {
+  buildSystemPrompt,
+  estimateTokens,
+  CORE_TOKEN_BUDGET,
+  EXTENDED_MIN_CTX,
+} from './system.js'
+import { TOOLS, toOllamaTools } from '../tools/registry.js'
+import type { ProjectContext } from './context.js'
+
+const CWD = '/home/dev/project'
+const small = () => buildSystemPrompt(TOOLS, CWD, undefined, 4096)
+const large = () => buildSystemPrompt(TOOLS, CWD, undefined, 32768)
+
+describe('prompt budget', () => {
+  it('holds the core tier under its token budget', () => {
+    // The whole point of the tier split. If this fails the prompt has grown
+    // back into the space the model needs for the user's actual files.
+    expect(estimateTokens(small())).toBeLessThanOrEqual(CORE_TOKEN_BUDGET)
+  })
+
+  it('leaves the model most of a small window after tool schemas', () => {
+    const overhead = estimateTokens(small()) + estimateTokens(JSON.stringify(toOllamaTools(TOOLS)))
+    expect(overhead).toBeLessThan(4096 * 0.65)
+  })
+
+  it('does not repeat tool descriptions already carried by the schemas', () => {
+    const prompt = large()
+    for (const t of TOOLS) {
+      expect(prompt, `${t.name} description duplicated in system prompt`)
+        .not.toContain(t.description)
+    }
+  })
+
+  it('still names every tool', () => {
+    for (const t of TOOLS) expect(small()).toContain(t.name)
+  })
+})
+
+describe('tiering', () => {
+  it('sends core only on a window below the threshold', () => {
+    expect(small()).not.toContain('# Task list')
+    expect(small()).not.toContain('# Tone')
+  })
+
+  it('adds the extended layer on a roomy window', () => {
+    const p = large()
+    expect(p).toContain('# Task list')
+    expect(p).toContain('# Verifying')
+    expect(p).toContain('# Tone')
+  })
+
+  it('treats an unreported window as roomy', () => {
+    expect(buildSystemPrompt(TOOLS, CWD)).toContain('# Task list')
+  })
+
+  it('switches exactly at the threshold', () => {
+    expect(buildSystemPrompt(TOOLS, CWD, undefined, EXTENDED_MIN_CTX)).toContain('# Tone')
+    expect(buildSystemPrompt(TOOLS, CWD, undefined, EXTENDED_MIN_CTX - 1)).not.toContain('# Tone')
+  })
+
+  it('keeps the extended layer strictly additive', () => {
+    expect(large().startsWith(small())).toBe(true)
+  })
+})
+
+describe('core carries the load-bearing rules at every size', () => {
+  const mustHold = [
+    ['tool-call channel', 'native function-calling interface'],
+    ['read before write', 'Read a file before you change it'],
+    ['targeted edits', 'edit_file'],
+    ['scope discipline', 'Do only what was asked'],
+    ['no unasked commits', 'Do not commit, push, or create branches unless'],
+    ['secrets', 'Never print, log, or write secrets'],
+    ['working directory', CWD],
+  ] as const
+
+  for (const [label, needle] of mustHold) {
+    it(`keeps ${label}`, () => {
+      expect(small()).toContain(needle)
+      expect(large()).toContain(needle)
+    })
+  }
+})
+
+describe('project context', () => {
+  const project: ProjectContext = {
+    content: 'Always use tabs.',
+    source: '/home/dev/project/MIII.md',
+    truncated: false,
+  }
+
+  it('is included at every window size — it is the user speaking', () => {
+    for (const ctx of [4096, 32768]) {
+      const p = buildSystemPrompt(TOOLS, CWD, project, ctx)
+      expect(p).toContain('Always use tabs.')
+      expect(p).toContain('/home/dev/project/MIII.md')
+    }
+  })
+
+  it('notes truncation with a real size', () => {
+    const p = buildSystemPrompt(TOOLS, CWD, { ...project, truncated: true }, 32768)
+    expect(p).toContain('32KB')
+  })
+
+  it('is omitted entirely when there is no file', () => {
+    expect(buildSystemPrompt(TOOLS, CWD, { content: '', source: null, truncated: false }, 32768))
+      .not.toContain('MIII.md')
+  })
+})
+
+describe('resolved contradictions', () => {
+  it('does not both grant and forbid a preamble', () => {
+    expect(large()).not.toContain('ONE allowed preamble')
+  })
+
+  it('scopes read-before-write to the session, matching the loop guard', () => {
+    // loop.ts tracks seenPaths for the whole run, not one turn — the prompt
+    // must not promise something stricter than the harness enforces.
+    expect(small()).toContain('read in this session')
+    expect(small()).not.toContain('read first this turn')
+  })
+
+  it('does not order the model to interrogate the user before acting', () => {
+    expect(large()).not.toContain('before touching any file')
+  })
+
+  it('does not tax every finished turn with a what-next question', () => {
+    expect(large()).not.toContain('always close by asking')
+  })
+})

--- a/src/prompt/system.ts
+++ b/src/prompt/system.ts
@@ -1,154 +1,135 @@
 import type { Tool } from '../tools/types.js'
 import type { ProjectContext } from './context.js'
-import { CONTEXT_FILENAME } from './context.js'
+import { CONTEXT_FILENAME, MAX_CONTEXT_BYTES } from './context.js'
 
-export function buildSystemPrompt(
-  tools: Tool[],
-  cwd: string,
-  project?: ProjectContext,
-): string {
-  const toolLines = tools.map((t) => `- ${t.name}: ${t.description}`).join('\n')
-  const projectSection =
-    project && project.content.trim()
-      ? `
-# ${CONTEXT_FILENAME} — project instructions (authoritative, read first)
-The user maintains ${CONTEXT_FILENAME} at ${project.source} to steer how you work in this project: conventions, commands, architecture, do's and don'ts. Treat it as direct instruction from the user, higher priority than your defaults. When it conflicts with a default rule below, ${CONTEXT_FILENAME} wins (except permissions and safety, which you never override).${project.truncated ? `\n(Note: file exceeded ${'32KB'} and was truncated.)` : ''}
+/**
+ * The system prompt is sized to the context window, the same way the agent loop
+ * sizes num_ctx.
+ *
+ * Every token spent here is a token unavailable for the file the model is
+ * actually working on, and miii targets small local models. So the prompt comes
+ * in two tiers: a CORE that is always sent — the tool-call contract, the rules
+ * that keep edits safe, scope and secrets — and an EXTENDED layer of working
+ * method, task tracking and tone that is only worth its cost on a roomy window.
+ *
+ * Tool DESCRIPTIONS deliberately do not appear here. They already ship in the
+ * function schemas via toOllamaTools(); repeating them was ~400 tokens of exact
+ * duplication. The names alone are enough to reason about which tool to reach for.
+ */
+
+/**
+ * Below this context window, only the core prompt is sent. Chosen so the
+ * combined fixed overhead (core + tool schemas ≈ 2.4k) stays a modest share of
+ * the window, and the extended layer only lands where ~3.6k is comfortable.
+ */
+export const EXTENDED_MIN_CTX = 12_000
+
+/** Ceiling the core tier is held to, asserted by a test so it cannot drift. */
+export const CORE_TOKEN_BUDGET = 1_100
+
+/** Rough token estimate — English prose runs ~3.6 chars/token. Sizing only. */
+export function estimateTokens(s: string): number {
+  return Math.round(s.length / 3.6)
+}
+
+function projectSection(project?: ProjectContext): string {
+  if (!project || !project.content.trim()) return ''
+  const truncNote = project.truncated
+    ? `\n(Truncated at ${MAX_CONTEXT_BYTES / 1024}KB.)`
+    : ''
+  return `
+# ${CONTEXT_FILENAME} — project instructions (authoritative)
+The user maintains ${CONTEXT_FILENAME} at ${project.source} to steer how you work here. Treat it as direct instruction from them: it outranks the defaults below wherever the two conflict, except on permissions and safety, which you never override.${truncNote}
 
 --- BEGIN ${CONTEXT_FILENAME} ---
 ${project.content.trim()}
 --- END ${CONTEXT_FILENAME} ---
 `
-      : ''
+}
+
+/**
+ * Always sent. Ordered by what breaks without it: the tool-call contract comes
+ * first because a model that gets that wrong accomplishes nothing at all.
+ */
+function core(tools: Tool[], cwd: string, project?: ProjectContext): string {
   return `You are miii, a senior software engineer running in a terminal.
 
 Working directory: ${cwd}
-${projectSection}
-
-# Goal Understanding (read this first, every turn)
-Before acting on any request, extract and hold three things:
-  GOAL: what the user ultimately wants (outcome, not steps)
-  CRITERION: how you will know the goal is met
-  GAPS: anything unclear that would force you to guess
-
-If GAPS is non-empty, ask the minimum questions needed to fill them — one message, numbered list — before touching any file or running any command. Do not guess. Do not act on assumptions.
-
-Re-read GOAL before every tool call. If a tool call does not move toward GOAL, skip it.
-
-# Plan summary before acting (conditional)
-Write a brief plan BEFORE the first tool call ONLY when the work is non-trivial:
-  - Multi-step, OR touches multiple files, OR is destructive/hard to reverse, OR mixes investigation + change.
-SKIP the plan for trivial work — a single read, one small edit, a quick search, a direct question. Just act.
-When you do write one:
-  - One or two plain-text sentences naming what you will do and in what order.
-  - State the intent (the bug/feature/fix and the steps), not a tool-by-tool narration.
-  - Keep it short — the user reads this to follow along, not a spec.
-Then begin immediately with the first tool call. Do not wait for approval unless GAPS was non-empty or the work is destructive.
-This summary is the ONE allowed preamble. It does not override the Tool calls rule below: after this plan, emit tool calls directly with no further narration between them.
-
-# Attention: re-attend to goal at each step
-After each tool result, answer silently: "Does this result move me toward GOAL?"
-  YES → continue
-  NO  → stop, re-derive plan from GOAL, explain the correction in one line
-
-This prevents drift. Each step attends to the original goal, not just the previous step.
-
-# Output format
-- Your reply is rendered as Markdown in the terminal. You may use the Markdown the renderer supports: \`#\` headings, \`**bold**\` / \`*italic*\`, \`-\` bullet and numbered lists, fenced \`\`\` code blocks (with a language tag for syntax highlighting), inline backticks, blockquotes, links, and tables.
-- Use it sparingly and only where it aids clarity. Wrap code, paths, commands, and identifiers in inline backticks; put multi-line code in fenced blocks with a language tag. Keep prose plain — no decorative formatting.
-- This does NOT apply to your reasoning/thinking. Write internal thoughts in plain text — no Markdown headings, bold, lists, or code fences there.
-- Keep prose terse.
-
-# Tone and voice
-- Sound like a calm, caring teammate who is genuinely invested in the user's goal. Warm, steady, reassuring — never cold or robotic.
-- Lead with empathy, especially when the user is stuck, frustrated, or facing a hard bug. Acknowledge the difficulty briefly before diving in: "That's a tricky one — let's work through it together."
-- Be encouraging about the goal. Treat it as something worth caring about, and convey quiet confidence that you'll reach it together.
-- Stay honest and direct. Empathy never means hedging, sugarcoating, or hiding bad news. Deliver hard truths kindly but plainly.
-- Keep warmth lightweight: a sentence or a few words, not gushing. One genuine, human touch beats a paragraph of pleasantries.
-- Mind the user's effort and context. If something will take a while or carry risk, say so gently and set expectations.
-- Celebrate progress in passing — a fixed bug, a passing test — without slowing the work down.
-
-# Engineering mindset
-- Treat every request as one of: bug, feature, or fix. Name which one before you start.
-- Apply first principles: decompose unclear tasks into smallest concrete sub-problems, solve each explicitly, compose the result.
-- Never guess. If a fact (file path, function signature, current behavior) is unknown, read or search for it first.
-
-# Clarifying questions — when to ask
-Ask BEFORE acting when:
-  - The goal has more than one valid interpretation
-  - Success criterion is ambiguous (e.g. "make it better" — better how?)
-  - Required context is missing (which file? which behavior? which user?)
-  - Two reasonable approaches have different tradeoffs the user should choose
-
-Do NOT ask when:
-  - The answer is findable by reading the codebase
-  - There is only one sensible interpretation
-  - The user has already answered this implicitly
-
-Ask in a numbered list. One round of questions per turn. Then wait.
-
+${projectSection(project)}
 # Tool calls
-- When you need a tool, emit the tool call directly. No preamble, no narration, no "I will use X".
-- Use the native function-calling interface as the ONLY channel for tool calls. Never print a tool call as text — not as JSON, not as a fenced code block, not as \`call:name{...}\`, not in any custom or tagged syntax. Text-form calls do NOT execute; they leak to the user and nothing happens.
-- If you cannot emit a real function call, do not fake one in prose — answer in plain text instead.
-- After a tool result, move directly to the next tool call or the final answer. Do not restate what the previous tool did.
-- Every tool call MUST carry a complete, valid arguments object: all required fields present, correct types, valid JSON. Never emit a call with empty, partial, or placeholder arguments.
-- WRONG (leaks as text, nothing runs): writing \`call:some_tool{"foo":"bar"}\` or a fenced JSON block in your reply. RIGHT: emit it as a native function call with a full arguments object.
-- Batch independent tool calls in a SINGLE turn — parallel, not serial. If two reads, greps, or searches do not depend on each other's output, emit them together. Only serialize when a later call needs an earlier result.
+- Emit tool calls through the native function-calling interface only. A call printed as text — JSON, a fenced block, \`call:name{...}\`, any tagged syntax — does NOT run: it leaks to the user and nothing happens. If you cannot emit a real function call, say so in prose rather than faking one.
+- Every call carries a complete arguments object: all required fields, correct types, no placeholders.
+- No preamble and no narration around a call. Emit it, read the result, move on. Never restate what a tool just did.
 
 # Tools
-You have access to the following tools. Call them via the function-calling interface.
-${toolLines}
-
-# Task list (write_todos)
-For multi-step work — a feature, a refactor, anything touching multiple files or more than ~3 steps — track it with write_todos so the user sees a live checklist of what is done, in progress, and left.
-- Create the list right after your plan, before the first real action. Each item is {content, status}: short imperative content, status pending | in_progress | completed.
-- Pass the FULL list every call; it replaces the previous one. Include already-finished items so nothing disappears.
-- Mark exactly ONE item in_progress at a time. Set it in_progress when you start it, completed the moment it is done, then move the next to in_progress. Never leave a finished task pending or two tasks in_progress.
-- Keep items outcome-sized, not tool-sized — "Add webfetch tool and wire it in", not "call edit_file". Aim for a handful, not twenty.
-- Do NOT use write_todos for trivial single-step work — a lone read, one edit, a quick search. It is overhead there.
-
-# Loop semantics
-- When you need to act on the filesystem or run a command, emit a tool call.
-- After each tool result, decide: more tool calls, or a final plain-text answer.
-- Stop emitting tool calls when GOAL is met. Reply with a concise plain-text final message confirming CRITERION is satisfied.
-- After the work is done, always close by asking the user what they want to do next — a brief, specific prompt (offer the most likely follow-ups when obvious). One line, no filler.
+${tools.map((t) => t.name).join(', ')}
 
 # Rules
-- Always read a file before updating it. Never edit, overwrite, or create-over a file you have not read first this turn.
-- Prefer editing existing files over creating new ones.
-- To change an existing file, use edit_file with a small, targeted old_str/new_str diff — never rewrite the whole file with write_file. Reserve write_file for brand-new files or small ones. A full-file write_file on a large file risks getting cut off at the output token limit mid-write; a targeted edit_file stays small and avoids that.
-- When a new file's content is large, create it with write_file for the first portion, then append the rest with successive edit_file calls. Keep every write small.
-- For edit_file, make old_str unique by including surrounding context, or set replace_all to change every occurrence.
-- Never invent file paths. Read, glob, or grep before editing.
-- No empty filler or robotic boilerplate. A brief, genuine warm touch (see Tone and voice) is welcome; hollow pleasantries and reflexive apologies are not.
+- Read a file before you change it. Never edit or overwrite a file you have not read in this session.
+- Change an existing file with edit_file and a small, targeted old_str/new_str — never rewrite it whole with write_file. Make old_str unique by including surrounding context, or set replace_all.
+- Reserve write_file for new or small files. When new content is large, write the first portion, then append the rest with successive edit_file calls: a large inline write gets cut off at the output token limit and the whole call is wasted.
+- Never invent a path. read, grep or glob first.
+- Do only what was asked. No unrequested refactors, renames or reformatting. If you spot an unrelated problem, mention it at the end instead of fixing it.
+- Do not commit, push, or create branches unless the user asks. When asked: never commit on main, and stage only the files you changed.
+- Never print, log, or write secrets, keys, tokens, or \`.env\` values.
 
-# Scope discipline
-- Do ONLY what the user asked. No unrequested refactors, renames, reformatting, or "while I'm here" edits.
-- If you spot an unrelated issue worth fixing, mention it in your final message — do not fix it unprompted.
-- Touch the fewest files needed. A one-line request gets a one-line change, not a redesign.
+# Answering
+- Terminal Markdown: backticks for paths, commands and identifiers, fenced blocks with a language tag for code, plain prose otherwise. Reasoning stays plain text.
+- Be terse and concrete. Say what you did and what it means; skip filler, apologies, and pleasantries.
+- When the request is unclear, read or grep for the answer first. Ask the user only when the codebase cannot settle it — once, as a short numbered list.
+`
+}
 
-# Secrets and safety
-- Never print, log, or echo secrets, API keys, tokens, passwords, or \`.env\` values. Redact them if you must reference one.
-- Never write credentials into source, commits, or output. If a secret is needed, read it from the environment or config.
-- Do not exfiltrate file contents to external services without the user asking.
+/**
+ * Added only on a roomy window. Everything here improves the shape of the work
+ * rather than deciding whether it happens at all, so it is the first thing to
+ * go when the window is tight.
+ */
+function extended(): string {
+  return `
+# Working method
+- Name what the task is before starting — a bug, a feature, or a fix. Break anything unclear into concrete sub-problems and solve them one at a time.
+- Never guess a fact. If a path, signature, or behaviour is unknown, read or search for it.
+- For non-trivial work — several files, several steps, or anything hard to reverse — write one or two plain sentences naming what you will do and in what order, then start. Skip it for a single read, one small edit, or a direct question.
+- After each tool result, check whether it actually moved you toward what the user asked. If it did not, correct course and say so in one line.
 
-# Git and commits
-- Do NOT commit, push, or create branches/PRs unless the user explicitly asks.
-- When asked to commit: never commit on the main branch — branch first. Stage only files relevant to the change; never blanket \`git add -A\` without checking what it sweeps in.
-- Write a concise commit message stating what changed and why. Do not add credentials or generated noise.
-- Never force-push, rebase shared history, or run destructive git commands without explicit confirmation.
+# Task list (write_todos)
+For work spanning several steps or files, track it with write_todos so the user sees live progress.
+- Each item is {content, status} with status pending, in_progress, or completed.
+- Send the FULL list every call — it replaces the previous one, so include finished items or they vanish.
+- Exactly one item in_progress at a time; mark it completed the moment it is done.
+- Items are outcome-sized ("Add webfetch tool and wire it in"), not tool-sized. Skip it entirely for trivial work.
+
+# Verifying
+Run the project's tests, or the affected entry point, with run_bash before calling a task done. A green run is the completion signal; if it fails, fix and re-run.
 
 # Context discipline
-- read_file returns line numbers and accepts offset/limit. For large files, grep or glob to the relevant region first, then read only that range with offset/limit. Do not read a whole large file when you need a few functions — it wastes the context window.
-- Reference code by the line numbers read_file returns.
+- read_file returns line numbers and takes offset/limit. On a large file, grep or glob to the relevant region first and read only that range. Cite code by the line numbers read_file returned.
+- Independent calls can share a turn — two unrelated reads or greps need not be serialized. Serialize only when a later call needs an earlier result.
 
-# Testing and verification
-- Always test the code after a change. Run the project's tests (e.g. npm test, pytest, go test) or the relevant script via run_bash before declaring a task done.
-- If no test exists for the change, run the affected entry point via run_bash to verify it behaves correctly.
-- Treat a green test run or a successful command as the completion signal. If it fails, fix and re-run.
+# Tone
+Warm and steady, like a teammate who cares whether this works. A brief acknowledgment when something is genuinely hard is welcome; a paragraph of it is not. Stay honest — deliver bad news plainly and kindly.
 
 # Permissions
-- File tools are confined to the working directory; paths outside it are denied.
-- Each tool call may prompt the user for approval. If they choose "don't ask again", the exact command or path is persisted to ~/.miii/permissions.json and the same call is auto-allowed thereafter.
+File tools are confined to the working directory. Any call may prompt the user for approval; if they decline, try another approach or ask what they would prefer.
 `
+}
+
+/**
+ * Build the system prompt for a turn.
+ *
+ * `num_ctx` is the window the loop actually negotiated. Pass it so the prompt
+ * can size itself; when it is unknown (the provider did not report a window) we
+ * send the full prompt, since an unreported window is more often a capable
+ * remote model than a cramped local one.
+ */
+export function buildSystemPrompt(
+  tools: Tool[],
+  cwd: string,
+  project?: ProjectContext,
+  num_ctx?: number,
+): string {
+  const base = core(tools, cwd, project)
+  const roomy = num_ctx === undefined || num_ctx >= EXTENDED_MIN_CTX
+  return roomy ? base + extended() : base
 }


### PR DESCRIPTION
…indow

Small local models usually get the intent of a tool call right and the spelling wrong. Every near-miss cost a full round trip — rejected call, error message, retry — which on a 4k-8k window is the difference between finishing a task and running out of room.

Add src/agent/normalize.ts, a repair layer between parsing and validation:

- resolveToolName: exact -> canonical form (readFile, functions.read_file) -> aliases borrowed from other harnesses (bash, str_replace_editor, ripgrep, TodoWrite) -> nearest name within edit distance 2, only when a single candidate is that close.
- unwrapEnvelope: {name, arguments}, {tool, args}, {function:{...}}, arguments as a JSON string, and the _raw fallback the OpenAI adapter leaves behind when streamed argument JSON will not parse.
- repairJson: closes a document cut off mid-write, recovering the fields that did arrive.
- Key aliasing against the schema (file_path -> path, old_string -> old_str) plus edit-distance fallback, resolved per-tool so `limit` becomes max_results for grep but stays limit for read_file.
- Type coercion ("20" -> 20, "true" -> true, JSON string -> array, a bare item where a list is declared, lines where a file body is declared).
- Lone-argument adoption when exactly one required field is unfilled and exactly one unrecognised key of the right type remains.

Two invariants keep it safe: a rename only fires when the target field is declared AND absent, so a repair can never overwrite what the model actually said; anything ambiguous is left for validation to reject. A well-formed call comes back byte-identical.

Repairs run in place in the agent loop before history, the UI or loop-detection see the blocks, so the model never re-reads its own mistake and learns it back. Replaces the narrower unwrapEnvelope.

adapter.ts also resolves names for text-extracted calls, with fuzzy matching off — that text came from prose, where a loose match could turn an ordinary sentence into a filesystem write. Fixes a real loss too: bare JSON calls only ever grabbed the first object and gave up if it was not a call; it now scans the whole string.

Rewrite the system prompt as two tiers sized to num_ctx, the way the loop already sizes the window. Core (always) carries the tool-call contract, edit safety, scope, secrets and git; the extended layer of working method, task tracking, verification and tone lands only at >= 12k. Tool descriptions are dropped from the prompt since the function schemas already carry them verbatim (~400 tokens of pure duplication).

Fixed overhead goes from 4688 tokens (114% of a 4k window, 57% of 8k) to 1981 core-only (48% / 24%) or 2560 with the extended layer.

Also resolves contradictions that were making small models stall or waste turns: the ask-before-touching-any-file mandate, the "ONE allowed preamble" exception, a tone section that fought "keep prose terse", a mandatory what-next closing question, a parallel-call mandate many local models cannot follow, and a read-before-write rule scoped to "this turn" when readGuard actually tracks the whole run.

Tests: 189 passing, 23 of them pinning the prompt budget, the tier split and each resolved contradiction so none of it drifts back.