### PR TITLE
ci: publish to npm via trusted publishing

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,6 +3,13 @@ name: release-please
 on:
   push:
     branches: [main]
+  # Manual recovery: publish an already-tagged release that failed to reach npm.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing release tag to publish to npm (e.g. miii-agent-v0.1.35). Leave empty to just run release-please."
+        required: false
+        default: ""
 
 permissions:
   contents: write
@@ -11,6 +18,7 @@ permissions:
 
 jobs:
   release-please:
+    if: github.event_name == 'push' || inputs.tag == ''
     runs-on: ubuntu-latest
     outputs:
       released: ${{ steps.rp.outputs.release_created }}
@@ -24,19 +32,24 @@ jobs:
 
   publish:
     needs: release-please
-    if: needs.release-please.outputs.released == 'true'
+    if: always() && (needs.release-please.outputs.released == 'true' || inputs.tag != '')
     runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write
     steps:
+      # Publish the tagged commit, not whatever main has drifted to.
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || needs.release-please.outputs.tag }}
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           registry-url: https://registry.npmjs.org
+      # Trusted Publishing (OIDC) needs npm >= 11.5.1; Node 20 ships npm 10.
+      - run: npm install -g npm@latest
       - run: npm ci
       - run: npm run build
-      - run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      # No NODE_AUTH_TOKEN: npm trusts this workflow via OIDC, and provenance
+      # is attached automatically.
+      - run: npm publish --access public


### PR DESCRIPTION
The npm token expired after 0.1.34 (2026-07-04), so every release since has tagged and released on GitHub but failed to reach npm — 0.1.35 is stranded. Granular tokens cap out at 90 days, so this recurs on a timer.

Authenticate with OIDC instead: no secret to rotate, and provenance is attached automatically (npm >= 11.5.1 required, hence the npm upgrade — the Node 20 runner ships npm 10).

Also check out the released tag rather than the default ref, and add a workflow_dispatch `tag` input so an already-tagged release that missed npm can be published without cutting a new version.