### PR TITLE
feat(ui): scrollback with mouse support, and a card for user messages

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -42,14 +42,39 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.tag || needs.release-please.outputs.tag }}
+      # Node 24 for npm 11, which can authenticate to npm over OIDC. Node 20
+      # ships npm 10, which cannot — that's what stranded 0.1.35.
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           registry-url: https://registry.npmjs.org
       - run: npm ci
       - run: npm run build
-      # NPM_TOKEN is a granular automation token; npm caps their lifetime at
-      # 90 days, so it has to be regenerated before it expires or this fails.
-      - run: npm publish --provenance --access public
+
+      # Already on npm? Then this is the manual-recovery path being re-run, or a
+      # version that was hand-published. Publishing again is a hard error, so
+      # skip instead of failing the release.
+      - id: check
+        run: |
+          version=$(node -p "require('./package.json').version")
+          if npm view "miii-agent@${version}" version >/dev/null 2>&1; then
+            echo "miii-agent@${version} is already on npm — nothing to publish."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Two ways in, so a release never waits on a secret being fresh:
+      #   1. Trusted publishing (OIDC). npm 11 exchanges this job's id-token for
+      #      a short-lived credential — nothing to rotate. Needs a trusted
+      #      publisher for miii-agent on npmjs.com, pointing at this repo and
+      #      this workflow file (Settings -> Trusted publisher).
+      #   2. NPM_TOKEN. Used when no trusted publisher is configured. Granular
+      #      tokens expire after at most 90 days, so this one needs regenerating
+      #      on a timer — which is how publishing broke after 0.1.34.
+      # npm tries OIDC first and falls back to the token, so both can be in
+      # place at once and whichever is working wins.
+      - if: steps.check.outputs.skip != 'true'
+        run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -102,7 +102,10 @@ Saved rules live in `~/.miii/permissions.json`.
 | `@filename` | Attach file to context |
 | `Ctrl+V` | Paste clipboard image (needs a vision model) |
 | `Ctrl+T` | Toggle the model's thinking |
-| `Ctrl+O` | Toggle full tool output |
+| `Ctrl+O` / left click | Toggle full tool output |
+| Mouse wheel | Scroll the transcript |
+| `PgUp` / `PgDn` | Scroll the transcript a page at a time |
+| `Shift+↑` / `Shift+↓` | Scroll the transcript a row at a time |
 | `Ctrl+A` / `Ctrl+E` | Jump to start / end of line |
 | `Esc` | Stop generation or tool run |
 | `Ctrl+C` | Quit |

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -2,6 +2,7 @@
 import { render } from 'ink'
 import { createElement } from 'react'
 import { App } from './ui/App.js'
+import { DISABLE as MOUSE_OFF } from './ui/mouse.js'
 import { cleanupSpill } from './tools/spill.js'
 import { setProvider, listProviders, configError, type Provider } from './config.js'
 
@@ -43,6 +44,10 @@ if (cmd === 'version' || cmd === '--version' || cmd === '-v') {
 
   // Restore the terminal tab title on any exit path (Ink's unmount cleanup
   // can be skipped on a hard signal).
-  process.on('exit', () => { if (process.stdout.isTTY) process.stdout.write('\x1b]2;\x07') })
+  // Mouse reporting gets the same treatment: a terminal left in click/wheel
+  // tracking mode swallows selection in whatever shell inherits it.
+  process.on('exit', () => {
+    if (process.stdout.isTTY) process.stdout.write(`\x1b]2;\x07${MOUSE_OFF}`)
+  })
   render(createElement(App))
 }

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -5,7 +5,7 @@
  * delegates streaming logic to useAgentRunner and key handling to useKeyboard.
  */
 import { useState, useEffect, useRef } from 'react'
-import { Box, Text, useApp } from 'ink'
+import { Box, Text, useApp, useStdout } from 'ink'
 import { homedir } from 'os'
 import { sep } from 'path'
 import { listModels, modelContext, isAvailable, NOT_AVAILABLE } from '../llm/client.js'
@@ -18,6 +18,7 @@ import { SessionsView } from './SessionsView.js'
 import { CommandPalette } from './CommandPalette.js'
 import { persistSession, setSessionTitle, summarizeConversation, newSessionId, type SessionMeta } from '../session/store.js'
 import { setTerminalTitle, resetTerminalTitle } from './terminalTitle.js'
+import { enableMouse, disableMouse } from './mouse.js'
 import { FilePicker, parseMention, searchFiles } from './FilePicker.js'
 import { ChatView } from './ChatView.js'
 import { useAgentRunner } from './hooks/useAgentRunner.js'
@@ -54,8 +55,8 @@ export function App() {
   sessionIdRef.current = sessionId
   const [sessions, setSessions] = useState<SessionMeta[]>([])
   const [notice, setNotice] = useState<string | null>(null)
-  // Bumped on /clear and /new to remount ChatView's <Static> so the welcome
-  // banner reprints after the hard-clear (Ink won't otherwise reflush it).
+  // Bumped on /clear and /new to remount ChatView's transcript so its measured
+  // height restarts from the empty log.
   const [logEpoch, setLogEpoch] = useState(0)
 
   // --- input bar ---
@@ -84,6 +85,24 @@ export function App() {
 
   // Restore the terminal tab title when miii exits (component unmounts).
   useEffect(() => resetTerminalTitle, [])
+
+  // The transcript scrolls inside the app's own viewport, so miii needs the
+  // wheel: ask the terminal to report clicks and wheel notches while it runs,
+  // and hand reporting back on the way out.
+  useEffect(() => {
+    enableMouse()
+    return disableMouse
+  }, [])
+
+  // Ink recalculates its layout on resize but doesn't re-render the tree, so the
+  // fixed-height root below would keep the old row count. Bump state to force it.
+  const { stdout } = useStdout()
+  const [termRows, setTermRows] = useState(stdout?.rows ?? 24)
+  useEffect(() => {
+    const onResize = () => setTermRows(stdout?.rows ?? 24)
+    stdout?.on('resize', onResize)
+    return () => { stdout?.off('resize', onResize) }
+  }, [stdout])
 
   // Tracks sessions whose LLM title has been generated, so we summarise once.
   const titledSessions = useRef<Set<string>>(new Set())
@@ -218,11 +237,18 @@ export function App() {
     return Math.round((used / activeCtx) * 100)
   })()
 
+  // Chat mode owns the whole screen: the root is pinned to the terminal height
+  // (less one row, so writing the frame can't scroll it) and ChatView's viewport
+  // flex-grows into whatever the input bar and pickers leave. Pre-ready screens
+  // stay auto-height — they're short, and a full-height frame there would just
+  // blank the terminal.
+  const fullScreen = state === 'ready' || state === 'sessions' || state === 'models'
+
   return (
-    <Box flexDirection="column" paddingX={1}>
-      {/* Pre-ready screens render the banner dynamically. In ready/chat mode the
-          banner moves into ChatView's <Static> log (Ink prints Static above the
-          live frame, so a dynamic banner here would sink below the scrollback). */}
+    <Box flexDirection="column" paddingX={1} height={fullScreen ? Math.max(8, termRows - 1) : undefined}>
+      {/* Pre-ready screens render the banner dynamically. In ready/chat mode it
+          moves inside the scrolling transcript, as its first row, so it scrolls
+          away with the rest of the history. */}
       {state !== 'ready' && state !== 'sessions' && state !== 'models' && (
         <WelcomeBlock variant="compact" model={cfg.model} activeCtx={activeCtx} effort={effort} cwd={cwd} provider={provName} error={agent.error} updateAvailable={updateAvailable} updateStatus={updateStatus} />
       )}
@@ -267,9 +293,12 @@ export function App() {
       )}
 
       {(state === 'ready' || state === 'sessions' || state === 'models') && (
+        // Everything except the transcript is flexShrink={0}: the root is pinned
+        // to the terminal height, and the viewport is what gives up rows when the
+        // palette, a picker or a warning needs them.
         <>
           {notice && (
-            <Box marginLeft={2} marginBottom={1}>
+            <Box marginLeft={2} marginBottom={1} flexShrink={0}>
               <Text color="green">{`✓ ${notice}`}</Text>
             </Box>
           )}
@@ -289,11 +318,13 @@ export function App() {
           />
 
           {state === 'ready' && input.startsWith('/') && (
-            <CommandPalette filter={input} cursor={paletteCursor} />
+            <Box flexShrink={0} flexDirection="column">
+              <CommandPalette filter={input} cursor={paletteCursor} />
+            </Box>
           )}
 
           {state === 'ready' && contextWarning !== null && (
-            <Box marginLeft={2} marginBottom={1}>
+            <Box marginLeft={2} marginBottom={1} flexShrink={0}>
               <Text color="yellow">
                 {`⚠ context ${contextWarning}% full — run /clear and start fresh`}
               </Text>
@@ -303,41 +334,51 @@ export function App() {
           {state === 'ready' && !input.startsWith('/') && (() => {
             const m = parseMention(input)
             if (!m) return null
-            return <FilePicker matches={searchFiles(process.cwd(), m.query)} cursor={filePickerCursor} />
+            return (
+              <Box flexShrink={0} flexDirection="column">
+                <FilePicker matches={searchFiles(process.cwd(), m.query)} cursor={filePickerCursor} />
+              </Box>
+            )
           })()}
 
           {/* Pickers have their own inline controls, so they drop the input bar
               entirely (avoids a stray "processing" prompt). */}
           {state === 'ready' && (
-            <InputBar
-              input={input}
-              caret={caret}
-              disabled={agent.busy}
-              processingLabel={agent.processingLabel}
-              hint={providerDown ? 'provider unavailable — /provider to switch · /models to pick a model' : undefined}
-            />
+            <Box flexShrink={0} flexDirection="column">
+              <InputBar
+                input={input}
+                caret={caret}
+                disabled={agent.busy}
+                processingLabel={agent.processingLabel}
+                hint={providerDown ? 'provider unavailable — /provider to switch · /models to pick a model' : undefined}
+              />
+            </Box>
           )}
 
           {/* Pickers render below the input bar (like the command palette) so the
-              single scrollback banner stays put — no duplicate header. */}
+              transcript's banner stays put — no duplicate header. */}
           {state === 'sessions' && (
-            <SessionsView sessions={sessions} cursor={cursor} />
+            <Box flexShrink={0} flexDirection="column">
+              <SessionsView sessions={sessions} cursor={cursor} />
+            </Box>
           )}
           {state === 'models' && (
-            <ModelsView
-              models={filteredModels}
-              cursor={cursor}
-              model={cfg.model}
-              host={provEntry.baseUrl}
-              provider={provName}
-              providerType={provEntry.type}
-              effort={effort}
-              query={pickerQuery}
-            />
+            <Box flexShrink={0} flexDirection="column">
+              <ModelsView
+                models={filteredModels}
+                cursor={cursor}
+                model={cfg.model}
+                host={provEntry.baseUrl}
+                provider={provName}
+                providerType={provEntry.type}
+                effort={effort}
+                query={pickerQuery}
+              />
+            </Box>
           )}
 
           {updateAvailable && (
-            <Box marginLeft={2} marginBottom={1}>
+            <Box marginLeft={2} marginBottom={1} flexShrink={0}>
               <Text color={updateStatus === 'failed' ? 'red' : updateStatus === 'installed' ? 'green' : 'yellow'}>
                 {updateBannerText(updateAvailable, updateStatus)}
               </Text>

--- a/src/ui/ChatView.tsx
+++ b/src/ui/ChatView.tsx
@@ -1,12 +1,13 @@
-import { type ReactNode } from 'react'
-import { Box, Text, Static } from 'ink'
+import { useEffect, useRef, useState, type ReactNode } from 'react'
+import { Box, Text, measureElement, type DOMElement } from 'ink'
 import { renderMarkdownStreaming } from './markdown.js'
 import { ThinkingBlock } from './ThinkingBlock.js'
 import type { ChatMessage, ToolUseDisplay, ToolResultDisplay, PermissionRequest } from './types.js'
 import { UserMessage, AssistantMessage } from './Message.js'
 import { ToolUseLine } from './ToolBlock.js'
 import { PermissionPrompt } from './PermissionPrompt.js'
-import { clipTail, clipTailVisual, visualHeight, liveFrameRows, contentWidth, estimateToolRows } from './layout.js'
+import { clipTail, clipTailVisual, contentWidth } from './layout.js'
+import { setScrollMetrics, useScroll } from './scroll.js'
 
 interface Props {
   messages: ChatMessage[]
@@ -19,15 +20,17 @@ interface Props {
   permissionCursor?: number
   activeToolUses?: ToolUseDisplay[]
   activeToolResults?: ToolResultDisplay[]
-  // Rendered once as the first line of the static scrollback log (e.g. the
-  // welcome banner). Omitted by pre-ready error views so no banner prints.
+  /** Rendered as the first row of the transcript (the welcome banner). */
   header?: ReactNode
-  // Bumped by /clear and /new. Ink's <Static> only writes each item once and
-  // tracks how many it has flushed, so after a hard-clear shrinks the log back
-  // to just the header it won't reprint it. Using this as the <Static> key
-  // remounts it (index resets to 0) so the header prints again on the clean screen.
+  /** Bumped by /clear and /new; remounts the transcript so measurement restarts. */
   logEpoch?: number
 }
+
+// While a turn streams, the in-flight answer is re-parsed on every 100ms flush;
+// markdown parsing is O(input), so a long reply would make late flushes lag.
+// Clipping the live buffer to a few screenfuls keeps each flush's cost flat —
+// the untruncated text renders once the turn commits to a message.
+const STREAM_VIEWPORTS = 3
 
 export function ChatView({
   messages,
@@ -43,45 +46,59 @@ export function ChatView({
   header,
   logEpoch = 0,
 }: Props) {
-  // Static log = finished, immutable scrollback. Ink's <Static> writes each item
-  // to stdout exactly once and never repaints it, so streaming flushes (which
-  // touch only the live frame below) can't trigger a full-history redraw — the
-  // root cause of the flicker. Order: header banner, then committed messages.
-  type LogItem = { key: string; node: ReactNode }
-  const log: LogItem[] = []
-  if (header) log.push({ key: 'header', node: header })
-  messages.forEach((msg, i) => {
-    log.push({
-      key: `msg-${i}`,
-      node: msg.role === 'user' ? <UserMessage msg={msg} /> : <AssistantMessage msg={msg} />,
-    })
+  const scroll = useScroll()
+
+  // Measured height of the full transcript. Ink lays the inner box out at its
+  // natural height (flexShrink 0) even though the viewport clips it, so this is
+  // the real content height — what scrolling has to clamp against.
+  const innerRef = useRef<DOMElement | null>(null)
+  const viewRef = useRef<DOMElement | null>(null)
+  const [contentRows, setContentRows] = useState(0)
+  // The viewport takes whatever rows the app's fixed-height root has left over
+  // after the input bar and any pickers, so its height is yoga's answer, not a
+  // guess — measured here because the scroll math needs it in rows.
+  const [viewportRows, setViewportRows] = useState(10)
+
+  const scrolled = !scroll.stick
+
+  useEffect(() => {
+    if (innerRef.current) {
+      const { height } = measureElement(innerRef.current)
+      if (height !== contentRows) setContentRows(height)
+    }
+    if (viewRef.current) {
+      const { height } = measureElement(viewRef.current)
+      if (height > 0 && height !== viewportRows) setViewportRows(height)
+    }
   })
 
-  // Live-frame row budget. Streaming text is clipped to it; the active tool
-  // blocks then get whatever rows remain. Keeping the whole live frame inside
-  // the terminal avoids Ink's full-screen clear path — the source of the flicker
-  // seen when a tool result lands and pushes the frame past the terminal height.
-  const liveBudget = liveFrameRows()
+  // Publish geometry for the wheel/pageup handlers, which run outside the tree.
+  useEffect(() => {
+    setScrollMetrics(contentRows, viewportRows)
+  }, [contentRows, viewportRows])
+
+  const maxTop = Math.max(0, contentRows - viewportRows)
+  // A scrolled-up view keeps its row, clamped in case the content shrank since
+  // the last measure.
+  const top = scroll.stick ? maxTop : Math.min(scroll.top, maxTop)
+  const below = maxTop - top
+  // Tail-following is done with flex, not the margin: bottom-aligning the inner
+  // box is exact on the frame it renders, whereas the margin depends on a height
+  // measured one render ago — which during streaming is a row out of date every
+  // time new output lands. Scrolled up, the content is frozen, so the measured
+  // offset is right and the margin does the work.
 
   let streamNode: ReactNode = null
-  let streamRows = 0
   if (streaming && streamingContent) {
-    // Clip the RAW buffer to the live budget first, then parse markdown on just
-    // that tail. Parsing (marked + syntax highlight) is O(input); rendering the
-    // whole accumulated answer every 100ms flush made late flushes on long
-    // replies lag and stutter. Bounding the input to ~terminal height keeps each
-    // flush's cost constant regardless of total answer length.
-    const raw = clipTail(streamingContent, liveBudget)
-    // Second clip is by VISUAL rows, not logical lines: the rendered markdown is
-    // drawn in a `wrap="wrap"` box at contentWidth, so a long line occupies
-    // several terminal rows. Counting logical lines let the live frame exceed the
-    // budget and overflow the terminal, forcing Ink's full-screen clear — the
-    // flicker. Mirrors the thinking block's clipTailVisual sizing.
+    // Clip the RAW buffer first, then parse markdown on just that tail: parsing
+    // the whole accumulated answer every flush is what made long replies stutter.
+    const budget = viewportRows * STREAM_VIEWPORTS
+    const raw = clipTail(streamingContent, budget)
+    // Second clip is by VISUAL rows: rendered markdown is drawn in a wrapping box
+    // at contentWidth, so one logical line can occupy several terminal rows.
     const width = contentWidth()
-    const rendered = clipTailVisual(renderMarkdownStreaming(raw.text), liveBudget, width)
-    const text = rendered.text
+    const rendered = clipTailVisual(renderMarkdownStreaming(raw.text), budget, width)
     const clipped = raw.clipped + rendered.clipped
-    streamRows = visualHeight(text, width) + (clipped > 0 ? 1 : 0)
     streamNode = (
       <Box flexDirection="column" marginBottom={1}>
         {clipped > 0 && (
@@ -89,75 +106,81 @@ export function ChatView({
         )}
         <Box flexDirection="row">
           <Text color="blue">{'● '}</Text>
-          <Box width={contentWidth()}>
-            <Text wrap="wrap">{text}</Text>
+          <Box width={width}>
+            <Text wrap="wrap">{rendered.text}</Text>
           </Box>
         </Box>
       </Box>
     )
   }
 
-  // Render active tool blocks from the most recent backwards, keeping only those
-  // that fit the remaining budget. Older ones reappear in scrollback once the
-  // turn commits to <Static>.
-  let toolNode: ReactNode = null
-  if (activeToolUses?.length) {
-    const remaining = Math.max(4, liveBudget - streamRows)
-    // Pair each use with its result once; both the budget pass and the render
-    // below need it, so resolving here avoids a second find() per kept tool.
-    const resultById = new Map(activeToolResults?.map((r) => [r.tool_use_id, r]))
-    const kept: Array<{ u: ToolUseDisplay; r?: ToolResultDisplay }> = []
-    let rows = 0
-    for (let i = activeToolUses.length - 1; i >= 0; i--) {
-      const u = activeToolUses[i]
-      const r = resultById.get(u.id)
-      const h = estimateToolRows(u, r)
-      if (rows + h > remaining && kept.length) break
-      rows += h
-      kept.unshift({ u, r })
-    }
-    const hidden = activeToolUses.length - kept.length
-    toolNode = (
-      <>
-        {hidden > 0 && (
-          <Text dimColor>{`↑ ${hidden} earlier tool call${hidden === 1 ? '' : 's'} above`}</Text>
-        )}
-        {kept.map(({ u, r }) => (
-          <ToolUseLine key={u.id} use={u} result={r} />
-        ))}
-      </>
-    )
-  }
+  // Every active tool block renders — the viewport clips what doesn't fit and the
+  // user can scroll back to the rest, so there's no row budget to keep here.
+  const resultById = new Map(activeToolResults?.map((r) => [r.tool_use_id, r]))
 
   return (
-    <>
-      <Static key={logEpoch} items={log}>
-        {(item) =>
-          item.key === 'header' ? (
-            <Box key={item.key}>{item.node}</Box>
-          ) : (
-            <Box key={item.key} marginLeft={1}>{item.node}</Box>
-          )
-        }
-      </Static>
+    <Box flexDirection="column" flexGrow={1}>
+      {/* Bottom-aligned while following the tail — which also puts a transcript
+          shorter than the viewport just above the input bar, instead of stranding
+          it under a screenful of blank rows. */}
+      <Box
+        ref={viewRef}
+        flexDirection="column"
+        flexGrow={1}
+        minHeight={4}
+        overflow="hidden"
+        justifyContent={scroll.stick || contentRows <= viewportRows ? 'flex-end' : 'flex-start'}
+      >
+        {/* Inner box holds the whole transcript at full height; the negative top
+            margin slides it under the clipping viewport. This is miii's own
+            scrollback — the terminal's is not used, so the wheel belongs to us. */}
+        <Box
+          key={logEpoch}
+          ref={innerRef}
+          flexDirection="column"
+          flexShrink={0}
+          marginTop={scroll.stick ? 0 : -top}
+        >
+          {header}
 
-      {/* Live frame — repaints freely; holds only the in-flight turn. */}
-      <Box flexDirection="column" marginLeft={1} marginBottom={1}>
-        {thinking && <ThinkingBlock content={thinkingContent} />}
+          {messages.map((msg, i) => (
+            <Box key={`msg-${i}`} marginLeft={1} flexShrink={0}>
+              {msg.role === 'user' ? <UserMessage msg={msg} /> : <AssistantMessage msg={msg} />}
+            </Box>
+          ))}
 
-        {streamNode}
+          <Box flexDirection="column" marginLeft={1} flexShrink={0}>
+            {thinking && <ThinkingBlock content={thinkingContent} />}
 
-        {toolNode}
+            {streamNode}
 
-        {pendingPermission && <PermissionPrompt req={pendingPermission} cursor={permissionCursor} />}
+            {activeToolUses?.map((u) => (
+              <ToolUseLine key={u.id} use={u} result={resultById.get(u.id)} />
+            ))}
 
-        {error && (
-          <Box flexDirection="row" marginBottom={1}>
-            <Text color="red">● </Text>
-            <Text color="red">{error}</Text>
+            {pendingPermission && <PermissionPrompt req={pendingPermission} cursor={permissionCursor} />}
+
+            {error && (
+              <Box flexDirection="row" marginBottom={1}>
+                <Text color="red">● </Text>
+                <Text color="red">{error}</Text>
+              </Box>
+            )}
           </Box>
-        )}
+        </Box>
       </Box>
-    </>
+
+      {/* Status row for the scroll position. Always one row, blank when following
+          the tail — a row that comes and goes re-flows the layout under it, and
+          the viewport's height is exactly what that reflow changes. The blank is a
+          space, not an empty string: Ink collapses an empty Text to zero rows. */}
+      <Box marginLeft={1} flexShrink={0}>
+        <Text dimColor>
+          {scrolled
+            ? `↓ ${below} more row${below === 1 ? '' : 's'} below · scroll down or pagedown to follow`
+            : ' '}
+        </Text>
+      </Box>
+    </Box>
   )
 }

--- a/src/ui/Message.tsx
+++ b/src/ui/Message.tsx
@@ -3,15 +3,37 @@ import { Box, Text } from 'ink'
 import { renderMarkdown } from './markdown.js'
 import type { ChatMessage } from './types.js'
 import { ToolUseLine } from './ToolBlock.js'
-import { formatTokens, formatDuration, contentWidth } from './layout.js'
+import { formatTokens, formatDuration, contentWidth, padLines, userTextWidth } from './layout.js'
+import { useTerminalWidth } from './hooks/useTerminalWidth.js'
+
+/**
+ * An echoed user message is drawn as a card: a coloured rule down the left edge
+ * and a filled body, so a turn reads as one object even when it wraps over
+ * several rows — the rule is what carries continuity down the block, and it's
+ * what keeps a wrapped message from looking like two.
+ *
+ * Colours are named rather than hex so they track the terminal's own palette
+ * instead of fighting a light or dark theme.
+ */
+const USER_BG = 'gray'
+const USER_ACCENT = 'blue'
+const USER_RULE = '\u258c'
 
 export const UserMessage = memo(function UserMessage({ msg }: { msg: ChatMessage }) {
+  // Read through the hook, not process.stdout: this component is memoised, so a
+  // resize would otherwise leave the block padded to the old width.
+  const cols = useTerminalWidth()
+  // Trailing blank lines would render as empty shaded rows hanging off the end
+  // of the card, so the content is trimmed to its last real line first.
+  const lines = padLines(msg.content.replace(/\s+$/, ''), userTextWidth(cols))
   return (
-    <Box flexDirection="row" marginBottom={1}>
-      <Text color="gray">❯ </Text>
-      <Box flexGrow={1}>
-        <Text>{msg.content}</Text>
-      </Box>
+    <Box flexDirection="column" marginBottom={1}>
+      {lines.map((line, i) => (
+        <Box key={i} flexDirection="row">
+          <Text color={USER_ACCENT}>{USER_RULE}</Text>
+          <Text backgroundColor={USER_BG}>{` ${line} `}</Text>
+        </Box>
+      ))}
     </Box>
   )
 })

--- a/src/ui/ToolBlock.tsx
+++ b/src/ui/ToolBlock.tsx
@@ -4,7 +4,7 @@ import type { ToolUseDisplay, ToolResultDisplay } from './types.js'
 import { useToolExpanded } from './toolExpand.js'
 import { countLines, truncate } from './layout.js'
 
-// Tool output is collapsed to a few lines by default; ctrl+o toggles full view.
+// Tool output is collapsed to a few lines by default; a click or ctrl+o toggles full view.
 const COLLAPSED_LINES = 3
 
 export const TOOL_LABEL: Record<string, string> = {
@@ -104,7 +104,7 @@ function FileEditBlock({
       })}
       {extra > 0 && (
         <Box marginLeft={4}>
-          <Text dimColor>… {extra} more lines · ctrl+o to expand</Text>
+          <Text dimColor>… {extra} more lines · click or ctrl+o to expand</Text>
         </Box>
       )}
     </Box>
@@ -237,7 +237,7 @@ function ToolResultBlock({ result, toolName }: { result: ToolResultDisplay; tool
       ))}
       {extra > 0 && (
         <Box marginLeft={4}>
-          <Text dimColor>… {extra} more lines · ctrl+o to expand</Text>
+          <Text dimColor>… {extra} more lines · click or ctrl+o to expand</Text>
         </Box>
       )}
     </Box>

--- a/src/ui/constants.ts
+++ b/src/ui/constants.ts
@@ -33,7 +33,7 @@ export const WELCOME_PROMPT = 'To get started, describe a task or try one of the
 export const INPUT_PLACEHOLDER = 'describe a task, or type / for commands'
 
 /** Key hints under the input bar. Kept short — they share one line. */
-export const INPUT_HINTS = '⏎ send · / commands · @ file · ctrl+v image · ctrl+t thinking'
+export const INPUT_HINTS = '⏎ send · / commands · @ file · ctrl+t thinking · scroll or pgup/pgdn to look back'
 
 /** Key hints under the input bar while a turn is running. */
-export const BUSY_HINTS = 'esc interrupt · ctrl+o expand tool output'
+export const BUSY_HINTS = 'esc interrupt · click or ctrl+o expand tool output · scroll to look back'

--- a/src/ui/hooks/useAgentRunner.ts
+++ b/src/ui/hooks/useAgentRunner.ts
@@ -194,8 +194,8 @@ export function useAgentRunner(model: string | undefined, activeCtx: number | nu
             // Final turn (non-tool stop): DON'T drop `streaming` here. The commit
             // (flushTurn with real tokens) can't run until the later 'done' event
             // lands, and an `await` sits between. Clearing `streaming` now would
-            // paint one frame with the live stream gone but the message not yet in
-            // <Static> — a blank flash, then a full reprint. Leaving `streaming`
+            // paint one frame with the live stream gone but the message not yet
+            // committed to the transcript — a blank flash, then a reprint. Leaving `streaming`
             // true keeps the rendered tail on screen until the post-loop
             // setStreaming(false)+flushTurn batch swaps it in atomically.
             break

--- a/src/ui/hooks/useKeyboard.ts
+++ b/src/ui/hooks/useKeyboard.ts
@@ -14,6 +14,8 @@ import { filteredCommands } from '../CommandPalette.js'
 import { invalidateFileCache, parseMention, searchFiles } from '../FilePicker.js'
 import { toggleThinkingVisible } from '../ThinkingBlock.js'
 import { toggleToolExpanded } from '../toolExpand.js'
+import { parseMouseEvent } from '../mouse.js'
+import { scrollBy, scrollToBottom, resetScroll } from '../scroll.js'
 import { setTerminalTitle, resetTerminalTitle } from '../terminalTitle.js'
 import {
   persistSession,
@@ -27,6 +29,12 @@ import {
 import type { useAgentRunner } from './useAgentRunner.js'
 
 const EFFORTS: Effort[] = ['low', 'medium', 'high']
+
+// Rows moved per wheel notch — three matches what terminals scroll natively.
+const WHEEL_ROWS = 3
+// A page is the visible transcript minus two rows of overlap, so you keep your
+// place across a jump.
+const PAGE_ROWS = () => Math.max(1, (process.stdout.rows ?? 24) - 8)
 
 // A paste collapses to a chip when it spans more than this many lines, or (for a
 // single huge line) exceeds the char fallback. Words are a poor proxy — pasted
@@ -181,7 +189,7 @@ interface KeyboardOptions {
   sessions: SessionMeta[]
   setSessions: (s: SessionMeta[]) => void
   setNotice: (s: string | null) => void
-  /** Bumped on /clear and /new to remount the <Static> log and reprint the banner. */
+  /** Bumped on /clear and /new to remount the transcript after a hard clear. */
   setLogEpoch: (fn: (n: number) => number) => void
 
   // provider switching
@@ -211,9 +219,9 @@ export function useKeyboard(opts: KeyboardOptions) {
   /**
    * Hard-clear the terminal: erase the screen AND the scrollback buffer, then
    * home the cursor (\x1b[2J = screen, \x1b[3J = scrollback, \x1b[H = home).
-   * Ink's <Static> log only writes each item once, so wiping the real terminal
-   * leaves the old transcript gone — the new command renders on a clean screen,
-   * like Claude Code.
+   * The transcript itself is state (cleared alongside this), so this is only
+   * about the terminal's own buffer: anything printed before miii started, and
+   * whatever Ink last painted, so the fresh session opens on a clean screen.
    */
   function hardClear() {
     write('\x1b[2J\x1b[3J\x1b[H')
@@ -230,14 +238,36 @@ export function useKeyboard(opts: KeyboardOptions) {
     setError(null)
     setNotice(null)
     clearPasteStore()
-    // Remount ChatView's <Static> so the welcome banner reprints on the freshly
-    // cleared screen; Ink otherwise treats it as already-flushed and skips it.
+    resetScroll()
+    // Remount the transcript so its measured height restarts from the empty log
+    // instead of the heights Ink last laid out.
     setLogEpoch((n) => n + 1)
   }
 
   const effort: Effort = cfg.effort ?? 'medium'
 
   useInput((char, key) => {
+    // --- mouse ---
+    // The transcript lives in miii's own viewport, so wheel notches scroll it
+    // (the terminal's scrollback isn't in play). Every report is swallowed here
+    // so an escape sequence can never land in the prompt. A left click toggles
+    // the collapsed tool output, same as ctrl+o.
+    const mouse = parseMouseEvent(char)
+    if (mouse) {
+      if (!mouse.press) return
+      if (mouse.wheel) scrollBy(mouse.up ? -WHEEL_ROWS : WHEEL_ROWS)
+      else if (mouse.button === 0) toggleToolExpanded()
+      return
+    }
+
+    // --- scrolling ---
+    if (key.pageUp) { scrollBy(-PAGE_ROWS()); return }
+    if (key.pageDown) { scrollBy(PAGE_ROWS()); return }
+    // shift+arrow nudges the view a line at a time, leaving the bare arrows to
+    // the pickers and history.
+    if (key.shift && key.upArrow) { scrollBy(-1); return }
+    if (key.shift && key.downArrow) { scrollBy(1); return }
+
     // --- global shortcuts ---
     if (key.ctrl && char === 'c') { exit(); return }
     // Ctrl+T toggles thinking block content visibility
@@ -355,6 +385,8 @@ export function useKeyboard(opts: KeyboardOptions) {
         setActiveToolResults([])
         setError(null)
         setSessionId(meta.id)
+        // A resumed transcript opens at its tail, like the session never left.
+        resetScroll()
         setTerminalTitle(meta.title)
         onResumeSession(meta.id)
         setNotice(`resumed · ${meta.title}`)
@@ -452,6 +484,9 @@ export function useKeyboard(opts: KeyboardOptions) {
 
       // submit / built-in commands
       if (key.return) {
+        // Whatever you were reading, sending snaps the view back to the tail so
+        // the reply is visible as it arrives.
+        scrollToBottom()
         const trimmed = input.trim()
         pushHistory(trimmed)
         historyIndex = -1

--- a/src/ui/hooks/useTerminalWidth.ts
+++ b/src/ui/hooks/useTerminalWidth.ts
@@ -1,0 +1,23 @@
+import { useEffect, useState } from 'react'
+import { useStdout } from 'ink'
+
+/**
+ * Terminal width in columns, tracked across resizes.
+ *
+ * A component that sizes itself by reading `process.stdout.columns` at render
+ * time goes stale behind React.memo: a resize changes no props, so the memo
+ * holds the previous frame at the old width. Subscribing here re-renders the
+ * component off its own state instead, without threading a width prop down.
+ */
+export function useTerminalWidth(): number {
+  const { stdout } = useStdout()
+  const [cols, setCols] = useState(stdout?.columns ?? 80)
+  useEffect(() => {
+    const onResize = () => setCols(stdout?.columns ?? 80)
+    stdout?.on('resize', onResize)
+    return () => {
+      stdout?.off('resize', onResize)
+    }
+  }, [stdout])
+  return cols
+}

--- a/src/ui/layout.test.ts
+++ b/src/ui/layout.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest'
+import { padLines, userTextWidth } from './layout.js'
+
+describe('padLines', () => {
+  it('pads a short line out to the full width', () => {
+    expect(padLines('hi', 6)).toEqual(['hi    '])
+  })
+
+  it('wraps on word boundaries and pads every row', () => {
+    const out = padLines('one two three', 7)
+    expect(out).toEqual(['one two', 'three  '])
+    expect(out.every((l) => l.length === 7)).toBe(true)
+  })
+
+  it('hard-breaks a word longer than the field', () => {
+    expect(padLines('abcdefgh', 3)).toEqual(['abc', 'def', 'gh '])
+  })
+
+  it('keeps blank source lines as a filled row', () => {
+    expect(padLines('a\n\nb', 2)).toEqual(['a ', '  ', 'b '])
+  })
+
+  it('yields a filled row for empty content, never a zero-height Text', () => {
+    expect(padLines('', 4)).toEqual(['    '])
+  })
+
+  it('never emits a row shorter or longer than the width', () => {
+    const out = padLines('the quick brown fox jumps over the lazy dog', 10)
+    expect(out.every((l) => l.length === 10)).toBe(true)
+  })
+})
+
+describe('userTextWidth', () => {
+  it('leaves room for the app padding, the rule and the body padding', () => {
+    expect(userTextWidth(80)).toBe(75)
+  })
+
+  it('floors on a narrow terminal rather than going negative', () => {
+    expect(userTextWidth(6)).toBe(8)
+    expect(userTextWidth(0)).toBe(8)
+  })
+})

--- a/src/ui/layout.ts
+++ b/src/ui/layout.ts
@@ -1,7 +1,5 @@
 // Pure formatting/sizing helpers shared across the chat UI components.
 
-import type { ToolUseDisplay, ToolResultDisplay } from './types.js'
-
 export function formatTokens(n: number): string {
   if (n >= 1000) return (n / 1000).toFixed(n >= 10000 ? 0 : 1) + 'k'
   return String(n)
@@ -28,8 +26,8 @@ export function truncate(s: string, max: number): string {
 // Clip rendered text to the last `max` lines. The live frame is redrawn in place
 // each streaming flush; if it grows taller than the terminal, Ink can't reach the
 // lines that scrolled off the top — causing flicker and orphaned blocks stuck in
-// scrollback. So we only ever show the tail here; the full text lands in the
-// <Static> log (real scrollback) once the turn commits.
+// re-parse. So we only ever show the tail here; the untruncated text renders
+// once the turn commits to a message.
 export function clipTail(rendered: string, max: number): { text: string; clipped: number } {
   const lines = rendered.split('\n')
   if (lines.length <= max) return { text: rendered, clipped: 0 }
@@ -42,18 +40,6 @@ export function clipTail(rendered: string, max: number): { text: string; clipped
 const ANSI_RE = /\x1b\[[0-9;]*m/g
 export function stripAnsi(s: string): string {
   return s.replace(ANSI_RE, '')
-}
-
-// Visible height (terminal rows) of already-rendered text at wrap `width`: each
-// logical line wraps to ceil(visibleLen / width) rows. ANSI codes are stripped
-// first so escape sequences aren't counted as columns.
-export function visualHeight(text: string, width: number): number {
-  const w = Math.max(1, width)
-  let rows = 0
-  for (const line of text.split('\n')) {
-    rows += Math.max(1, Math.ceil(stripAnsi(line).length / w))
-  }
-  return rows
 }
 
 // Clip text to the last lines that fit `maxRows` of VISUAL rows at the given
@@ -88,59 +74,6 @@ export function liveFrameRows(): number {
   return Math.max(6, rows - 8)
 }
 
-// Estimated rendered height (rows) of a live tool block, matching the collapsed
-// layout in ToolBlock. Used to keep the active-tool region inside the live-frame
-// budget — an overflowing live frame forces Ink's full-screen clear, which is the
-// flicker. The expanded (ctrl+o) view is the user's choice and is not budgeted.
-const COLLAPSED_LINES = 3
-// Visual height of a block of text: each logical line wraps to ceil(len/width)
-// terminal rows. Counting logical lines alone under-estimates a long single-line
-// bash/grep result, letting the live frame overflow the terminal — which forces
-// Ink's full-screen erase, the flicker. Mirrors clipTailVisual's row model.
-function visualRows(text: string, width: number, cap: number): number {
-  const w = Math.max(1, width)
-  let rows = 0
-  const lines = text.split('\n')
-  for (const line of lines) {
-    rows += Math.max(1, Math.ceil(line.length / w))
-    if (rows >= cap) return cap
-  }
-  return rows
-}
-
-export function estimateToolRows(use: ToolUseDisplay, result?: ToolResultDisplay): number {
-  const input = (use.input ?? {}) as Record<string, unknown>
-  const noErr = !result?.is_error
-  const w = contentWidth()
-  // write/edit render a header + summary + (clipped) diff preview.
-  if (use.name === 'write_file' && noErr) {
-    const total = countLines(String(input.content ?? ''))
-    const shown = Math.min(total, COLLAPSED_LINES)
-    return 2 + shown + (total > shown ? 1 : 0)
-  }
-  if (use.name === 'edit_file' && noErr) {
-    const total = countLines(String(input.old_str ?? '')) + countLines(String(input.new_str ?? ''))
-    const shown = Math.min(total, COLLAPSED_LINES)
-    return 2 + shown + (total > shown ? 1 : 0)
-  }
-  let rows = 1 // header line
-  if (result) {
-    const lines = (result.content ?? '').split('\n')
-    const multi =
-      (use.name === 'run_bash' || use.name === 'grep' || use.name === 'glob' || result.is_error) &&
-      lines.length > 1
-    if (multi) {
-      // Only the first COLLAPSED_LINES show; count their WRAPPED height so a
-      // long line isn't mis-budgeted as one row.
-      const shownLines = lines.slice(0, COLLAPSED_LINES).join('\n')
-      rows += 1 + visualRows(shownLines, w, COLLAPSED_LINES * 4) + (lines.length > COLLAPSED_LINES ? 1 : 0)
-    } else {
-      rows += visualRows(lines[0] ?? '', w, 4)
-    }
-  }
-  return rows
-}
-
 // Width for assistant prose: marked emits long unwrapped lines, and the content
 // sits offset by the `● ` bullet (2 cols) plus a left margin (1). Without an
 // explicit width Ink wraps to the full terminal, overrunning the offset and
@@ -148,4 +81,45 @@ export function estimateToolRows(use: ToolUseDisplay, result?: ToolResultDisplay
 // content column. Floor keeps it sane on narrow terminals.
 export function contentWidth(): number {
   return Math.max(20, (process.stdout.columns ?? 80) - 4)
+}
+
+// Wrap `content` to `width` columns and pad every row out to exactly that many,
+// so a background color paints a clean rectangle instead of hugging ragged text.
+// Ink 5 has no Box-level background, so the fill has to come from the string
+// itself; each source line yields at least one row, and words longer than the
+// field are hard-broken rather than allowed to overrun it.
+export function padLines(content: string, width: number): string[] {
+  const w = Math.max(1, width)
+  const out: string[] = []
+  for (const para of content.split('\n')) {
+    const before = out.length
+    let line = ''
+    for (const word of para.split(' ')) {
+      let rest = word
+      while (rest.length > w) {
+        if (line) out.push(line)
+        out.push(rest.slice(0, w))
+        line = ''
+        rest = rest.slice(w)
+      }
+      if (rest === '') continue
+      if (!line) line = rest
+      else if (line.length + 1 + rest.length <= w) line += ' ' + rest
+      else {
+        out.push(line)
+        line = rest
+      }
+    }
+    if (line !== '') out.push(line)
+    else if (out.length === before) out.push('')
+  }
+  return out.map((l) => l + ' '.repeat(Math.max(0, w - l.length)))
+}
+
+// Text columns inside a user message block, for a terminal `cols` wide. The app
+// pads 1 either side, the accent rule takes 1, and the shaded body carries 1
+// column of its own padding either side so the fill never sits flush against
+// the glyphs. Floor keeps it usable on narrow terminals.
+export function userTextWidth(cols: number): number {
+  return Math.max(8, cols - 5)
 }

--- a/src/ui/mouse.test.ts
+++ b/src/ui/mouse.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest'
+import { parseMouseEvent } from './mouse.js'
+
+describe('parseMouseEvent', () => {
+  it('parses a left-button press', () => {
+    expect(parseMouseEvent('[<0;12;30M')).toEqual({
+      button: 0, x: 12, y: 30, press: true, wheel: false, up: true,
+    })
+  })
+
+  it('parses a release', () => {
+    expect(parseMouseEvent('[<0;12;30m')?.press).toBe(false)
+  })
+
+  it('masks modifier bits off the button', () => {
+    // 16 = ctrl held, still the left button.
+    expect(parseMouseEvent('[<16;1;1M')?.button).toBe(0)
+  })
+
+  it('tells wheel up from wheel down', () => {
+    const up = parseMouseEvent('[<64;1;1M')
+    const down = parseMouseEvent('[<65;1;1M')
+    expect(up).toMatchObject({ wheel: true, up: true })
+    expect(down).toMatchObject({ wheel: true, up: false })
+  })
+
+  it('ignores ordinary typing and other escape sequences', () => {
+    expect(parseMouseEvent('a')).toBeNull()
+    expect(parseMouseEvent('[A')).toBeNull()
+    expect(parseMouseEvent('[<0;1M')).toBeNull()
+  })
+})

--- a/src/ui/mouse.ts
+++ b/src/ui/mouse.ts
@@ -1,0 +1,63 @@
+/**
+ * mouse — terminal mouse reporting.
+ *
+ * The transcript scrolls inside miii's own viewport (see scroll.ts), so the app
+ * needs the wheel: this turns on xterm button tracking (mode 1000) with
+ * SGR-encoded reports (mode 1006). Motion tracking is deliberately left off, so
+ * the terminal keeps as much native behaviour as it can — drag-to-select still
+ * works with the usual override (option-drag on macOS, shift-drag elsewhere).
+ *
+ * Reports arrive on stdin as `ESC [ < b ; x ; y M|m`. Ink's parse-keypress
+ * leaves them intact and strips only the leading ESC, so the keyboard handler
+ * matches them with parseMouseEvent() and swallows them before they can reach
+ * the input bar.
+ */
+const ENABLE = '\x1b[?1000h\x1b[?1006h'
+export const DISABLE = '\x1b[?1006l\x1b[?1000l'
+
+// SGR report minus the ESC that Ink strips: `[<button;col;row` + M (press) / m (release).
+const SGR_RE = /^\[<(\d+);(\d+);(\d+)([Mm])$/
+
+export type MouseEvent = {
+  /** Button number with the modifier/motion bits masked off (0 = left). */
+  button: number
+  /** 1-based terminal column and row. */
+  x: number
+  y: number
+  /** true = button press, false = release. */
+  press: boolean
+  /** Wheel notch rather than a button; `up` says which way. */
+  wheel: boolean
+  up: boolean
+}
+
+let enabled = false
+
+export function enableMouse(): void {
+  if (enabled || !process.stdout.isTTY) return
+  enabled = true
+  process.stdout.write(ENABLE)
+}
+
+export function disableMouse(): void {
+  if (!enabled) return
+  enabled = false
+  if (process.stdout.isTTY) process.stdout.write(DISABLE)
+}
+
+/** Parse one useInput chunk as a mouse report; null when it isn't one. */
+export function parseMouseEvent(input: string): MouseEvent | null {
+  const m = SGR_RE.exec(input)
+  if (!m) return null
+  const raw = Number(m[1])
+  // Low 2 bits are the button (or the wheel direction); 4/8/16 are
+  // shift/meta/ctrl, 32 is motion, 64 marks a wheel notch.
+  return {
+    button: raw & 3,
+    x: Number(m[2]),
+    y: Number(m[3]),
+    press: m[4] === 'M',
+    wheel: (raw & 64) !== 0,
+    up: (raw & 1) === 0,
+  }
+}

--- a/src/ui/scroll.test.ts
+++ b/src/ui/scroll.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { setScrollMetrics, scrollBy, scrollToBottom, resetScroll, maxScrollTop, __scrollState } from './scroll.js'
+
+describe('scroll', () => {
+  beforeEach(() => {
+    resetScroll()
+    // 100 rows of transcript in a 20-row viewport.
+    setScrollMetrics(100, 20)
+  })
+
+  it('starts pinned to the tail', () => {
+    expect(__scrollState()).toEqual({ top: 0, stick: true })
+    expect(maxScrollTop()).toBe(80)
+  })
+
+  it('scrolls up from the tail, not from row 0', () => {
+    scrollBy(-3)
+    expect(__scrollState()).toEqual({ top: 77, stick: false })
+  })
+
+  it('clamps at the top', () => {
+    scrollBy(-1000)
+    expect(__scrollState()).toEqual({ top: 0, stick: false })
+  })
+
+  it('re-arms tail-following on reaching the bottom', () => {
+    scrollBy(-10)
+    scrollBy(10)
+    expect(__scrollState()).toEqual({ top: 80, stick: true })
+  })
+
+  it('jumps back to the tail', () => {
+    scrollBy(-40)
+    scrollToBottom()
+    expect(__scrollState()).toEqual({ top: 80, stick: true })
+  })
+
+  it('has nothing to scroll when the transcript fits', () => {
+    setScrollMetrics(10, 20)
+    expect(maxScrollTop()).toBe(0)
+    scrollBy(-5)
+    expect(__scrollState()).toEqual({ top: 0, stick: true })
+  })
+})

--- a/src/ui/scroll.ts
+++ b/src/ui/scroll.ts
@@ -1,0 +1,85 @@
+import { useState, useEffect } from 'react'
+
+/**
+ * scroll — viewport scroll position for the chat transcript.
+ *
+ * The transcript is rendered into a fixed-height clipped viewport (ChatView)
+ * rather than the terminal's own scrollback, so miii owns scrolling: the mouse
+ * wheel and pageup/pagedown move this offset. Module-level store + subscriber
+ * set, mirroring toolExpand, so the input handler can scroll without threading
+ * state through the tree.
+ *
+ * `top` is the first visible content row. `stick` means "follow the tail": while
+ * it's set the view pins to the bottom as new output lands, which is what you
+ * want during a turn. Scrolling up clears it; scrolling back to the bottom (or
+ * sending a message) sets it again.
+ */
+type ScrollState = { top: number; stick: boolean }
+
+let state: ScrollState = { top: 0, stick: true }
+const listeners = new Set<() => void>()
+
+// Last rendered geometry, published by ChatView. Scrolling has to clamp against
+// the content height, and the handlers that drive it live outside the view.
+let contentHeight = 0
+let viewportHeight = 0
+
+function emit() {
+  listeners.forEach((fn) => fn())
+}
+
+/** Called by ChatView after each measure so scroll commands can clamp. */
+export function setScrollMetrics(content: number, viewport: number): void {
+  contentHeight = content
+  viewportHeight = viewport
+}
+
+export function maxScrollTop(): number {
+  return Math.max(0, contentHeight - viewportHeight)
+}
+
+/** Move by `delta` rows (negative = towards older output). */
+export function scrollBy(delta: number): void {
+  const max = maxScrollTop()
+  const from = state.stick ? max : Math.min(state.top, max)
+  const top = Math.max(0, Math.min(max, from + delta))
+  // Landing on the last row re-arms tail-following, so a scroll back down
+  // behaves like a terminal that was never scrolled.
+  const next = { top, stick: top >= max }
+  if (next.top === state.top && next.stick === state.stick) return
+  state = next
+  emit()
+}
+
+/** Jump back to the tail and resume following it. */
+export function scrollToBottom(): void {
+  if (state.stick) return
+  state = { top: maxScrollTop(), stick: true }
+  emit()
+}
+
+/** Reset for a fresh transcript (/clear, /new, session load). */
+export function resetScroll(): void {
+  state = { top: 0, stick: true }
+  emit()
+}
+
+/** Measured geometry — for tests. */
+export function __scrollMetrics(): { content: number; viewport: number } {
+  return { content: contentHeight, viewport: viewportHeight }
+}
+
+/** Current position — for tests; components use useScroll(). */
+export function __scrollState(): ScrollState {
+  return state
+}
+
+export function useScroll(): ScrollState {
+  const [s, setS] = useState(state)
+  useEffect(() => {
+    const handler = () => setS(state)
+    listeners.add(handler)
+    return () => { listeners.delete(handler) }
+  }, [])
+  return s
+}

--- a/src/ui/toolExpand.ts
+++ b/src/ui/toolExpand.ts
@@ -1,7 +1,8 @@
 import { useState, useEffect } from 'react'
 
-// Tool output is collapsed to a few lines by default; ctrl+o toggles full view.
-// Global flag + subscriber set so the keyboard handler can flip every mounted
+// Tool output is collapsed to a few lines by default; a click or ctrl+o toggles
+// full view.
+// Global flag + subscriber set so the input handler can flip every mounted
 // tool block at once without threading state through the component tree.
 let globalToolExpanded = false
 const toolExpandListeners = new Set<() => void>()


### PR DESCRIPTION
Adds wheel and click reporting (mouse.ts) and a scroll model (scroll.ts) behind the chat viewport, reworking ChatView, App and useKeyboard around them so the transcript scrolls without forcing Ink's full-screen redraw.

Echoed user messages are now drawn as a card — a coloured rule down the left edge and a filled body — so a turn reads as one object even when it wraps. Ink 5 has no Box-level background, so layout.padLines wraps the text and pads each row out to fill the block. Width comes through useTerminalWidth rather than process.stdout, since the memoised message would otherwise keep the old width across a resize.