### PR TITLE
fix(ui): swallow coalesced mouse reports so they can't reach the prompt

### DIFF
--- a/src/ui/hooks/useKeyboard.ts
+++ b/src/ui/hooks/useKeyboard.ts
@@ -14,7 +14,7 @@ import { filteredCommands } from '../CommandPalette.js'
 import { invalidateFileCache, parseMention, searchFiles } from '../FilePicker.js'
 import { toggleThinkingVisible } from '../ThinkingBlock.js'
 import { toggleToolExpanded } from '../toolExpand.js'
-import { parseMouseEvent } from '../mouse.js'
+import { parseMouseEvents } from '../mouse.js'
 import { scrollBy, scrollToBottom, resetScroll } from '../scroll.js'
 import { setTerminalTitle, resetTerminalTitle } from '../terminalTitle.js'
 import {
@@ -250,13 +250,19 @@ export function useKeyboard(opts: KeyboardOptions) {
     // --- mouse ---
     // The transcript lives in miii's own viewport, so wheel notches scroll it
     // (the terminal's scrollback isn't in play). Every report is swallowed here
-    // so an escape sequence can never land in the prompt. A left click toggles
-    // the collapsed tool output, same as ctrl+o.
-    const mouse = parseMouseEvent(char)
-    if (mouse) {
-      if (!mouse.press) return
-      if (mouse.wheel) scrollBy(mouse.up ? -WHEEL_ROWS : WHEEL_ROWS)
-      else if (mouse.button === 0) toggleToolExpanded()
+    // so an escape sequence can never land in the prompt — a spin of the wheel
+    // packs several into one chunk, so they're drained as a batch and the wheel
+    // rows summed into a single scroll. A left click toggles the collapsed tool
+    // output, same as ctrl+o.
+    const mouse = parseMouseEvents(char)
+    if (mouse.consumed) {
+      let rows = 0
+      for (const ev of mouse.events) {
+        if (!ev.press) continue
+        if (ev.wheel) rows += ev.up ? -WHEEL_ROWS : WHEEL_ROWS
+        else if (ev.button === 0) toggleToolExpanded()
+      }
+      if (rows !== 0) scrollBy(rows)
       return
     }
 

--- a/src/ui/mouse.test.ts
+++ b/src/ui/mouse.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest'
-import { parseMouseEvent } from './mouse.js'
+import { describe, it, expect, beforeEach } from 'vitest'
+import { parseMouseEvent, parseMouseEvents, resetMouseParser } from './mouse.js'
 
 describe('parseMouseEvent', () => {
   it('parses a left-button press', () => {
@@ -28,5 +28,33 @@ describe('parseMouseEvent', () => {
     expect(parseMouseEvent('a')).toBeNull()
     expect(parseMouseEvent('[A')).toBeNull()
     expect(parseMouseEvent('[<0;1M')).toBeNull()
+  })
+})
+
+describe('parseMouseEvents', () => {
+  beforeEach(resetMouseParser)
+
+  it('drains a chunk holding several coalesced reports', () => {
+    const chunk = '[<65;79;23M\x1b[<65;79;23M\x1b[<64;80;24M'
+    const { events, rest, consumed } = parseMouseEvents(chunk)
+    expect(consumed).toBe(true)
+    expect(rest).toBe('')
+    expect(events.map((e) => e.up)).toEqual([false, false, true])
+  })
+
+  it('swallows a report torn across two chunks', () => {
+    const first = parseMouseEvents('[<65;79;23M\x1b[<65;79')
+    expect(first.events).toHaveLength(1)
+    expect(first.rest).toBe('')
+    const second = parseMouseEvents(';23M\x1b[<64;1;1M')
+    expect(second.rest).toBe('')
+    expect(second.events).toHaveLength(1)
+  })
+
+  it('leaves ordinary typing alone', () => {
+    const { events, rest, consumed } = parseMouseEvents('[<')
+    expect(events).toEqual([])
+    expect(consumed).toBe(false)
+    expect(rest).toBe('[<')
   })
 })

--- a/src/ui/mouse.ts
+++ b/src/ui/mouse.ts
@@ -9,14 +9,23 @@
  *
  * Reports arrive on stdin as `ESC [ < b ; x ; y M|m`. Ink's parse-keypress
  * leaves them intact and strips only the leading ESC, so the keyboard handler
- * matches them with parseMouseEvent() and swallows them before they can reach
- * the input bar.
+ * matches them with parseMouseEvents() and swallows them before they can reach
+ * the input bar. A fast wheel spin or a drag emits reports quicker than the
+ * event loop drains stdin, so a single chunk routinely holds several of them
+ * (every one after the first keeping its own ESC) and can even be cut mid
+ * report — hence the multi-event scan and the carried-over tail.
  */
 const ENABLE = '\x1b[?1000h\x1b[?1006h'
 export const DISABLE = '\x1b[?1006l\x1b[?1000l'
 
 // SGR report minus the ESC that Ink strips: `[<button;col;row` + M (press) / m (release).
 const SGR_RE = /^\[<(\d+);(\d+);(\d+)([Mm])$/
+// The same report anywhere in a chunk; only the first has had its ESC stripped.
+const SGR_ALL_RE = /\x1b?\[<(\d+);(\d+);(\d+)([Mm])/g
+// A report severed by a chunk boundary: its head (`[<65;79`), then its tail
+// (`;23M`) at the start of the chunk that follows.
+const HEAD_RE = /\x1b?\[<[\d;]*$/
+const TAIL_RE = /^[\d;]*[Mm]/
 
 export type MouseEvent = {
   /** Button number with the modifier/motion bits masked off (0 = left). */
@@ -45,19 +54,71 @@ export function disableMouse(): void {
   if (process.stdout.isTTY) process.stdout.write(DISABLE)
 }
 
-/** Parse one useInput chunk as a mouse report; null when it isn't one. */
-export function parseMouseEvent(input: string): MouseEvent | null {
-  const m = SGR_RE.exec(input)
-  if (!m) return null
-  const raw = Number(m[1])
+function toEvent(b: string, x: string, y: string, end: string): MouseEvent {
+  const raw = Number(b)
   // Low 2 bits are the button (or the wheel direction); 4/8/16 are
   // shift/meta/ctrl, 32 is motion, 64 marks a wheel notch.
   return {
     button: raw & 3,
-    x: Number(m[2]),
-    y: Number(m[3]),
-    press: m[4] === 'M',
+    x: Number(x),
+    y: Number(y),
+    press: end === 'M',
     wheel: (raw & 64) !== 0,
     up: (raw & 1) === 0,
   }
+}
+
+/** Parse one useInput chunk as a single mouse report; null when it isn't one. */
+export function parseMouseEvent(input: string): MouseEvent | null {
+  const m = SGR_RE.exec(input)
+  return m ? toEvent(m[1]!, m[2]!, m[3]!, m[4]!) : null
+}
+
+// Set when a chunk ended mid-report, so the tail arriving next can be dropped.
+let pendingTail = false
+
+/** Forget a carried-over partial report (tests, and after a stdin reset). */
+export function resetMouseParser(): void {
+  pendingTail = false
+}
+
+/**
+ * Pull every mouse report out of one useInput chunk.
+ *
+ * `rest` is what's left once they're removed, and `consumed` says whether
+ * anything mouse-shaped was stripped at all — a torn report yields no event but
+ * still must not reach the prompt. A dangling head is only trusted when the
+ * chunk also held a whole report, so typing a bare `[<` is never swallowed.
+ */
+export function parseMouseEvents(
+  input: string,
+): { events: MouseEvent[]; rest: string; consumed: boolean } {
+  let rest = input
+  let consumed = false
+
+  if (pendingTail) {
+    pendingTail = false
+    const tail = TAIL_RE.exec(rest)
+    if (tail) {
+      rest = rest.slice(tail[0].length)
+      consumed = true
+    }
+  }
+
+  const events: MouseEvent[] = []
+  rest = rest.replace(SGR_ALL_RE, (_m, b: string, x: string, y: string, end: string) => {
+    events.push(toEvent(b, x, y, end))
+    return ''
+  })
+
+  if (events.length > 0) {
+    consumed = true
+    const head = HEAD_RE.exec(rest)
+    if (head) {
+      rest = rest.slice(0, rest.length - head[0].length)
+      pendingTail = true
+    }
+  }
+
+  return { events, rest, consumed }
 }


### PR DESCRIPTION
parseMouseEvent was anchored, so it only matched a chunk holding exactly one SGR report. A wheel spin or a drag emits reports faster than the event loop drains stdin, so several arrive in one chunk and the match failed — the whole blob landed in the input bar as literal text.

parseMouseEvents scans out every report in a chunk (each after the first still carrying its own ESC) and reports whether anything was consumed. A report severed at a chunk boundary is stripped too, but only when the same chunk held a complete one, so typing a bare `[<` is never eaten. Wheel notches in a batch now sum into a single scroll.