### PR TITLE
feat(ui): compact a full context, and copy text out of the transcript

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ Saved rules live in `~/.miii/permissions.json`.
 | `Shift+↑` / `Shift+↓` | Scroll the transcript a row at a time |
 | `Ctrl+A` / `Ctrl+E` | Jump to start / end of line |
 | `Esc` | Stop generation or tool run |
+| `Ctrl+Y` | Copy the last reply to the clipboard |
+| `Ctrl+S` | Hand the mouse back to the terminal, so a drag selects text |
 | `Ctrl+C` | Quit |
 
 | Command | Action |
@@ -116,6 +118,8 @@ Saved rules live in `~/.miii/permissions.json`.
 | `/provider` | Pick a configured provider |
 | `/new` | Save this session and start fresh |
 | `/sessions` | List and resume a saved session |
+| `/copy` | Copy to the clipboard — `last` (default), `code`, `tool` or `all` |
+| `/compact` | Summarize the conversation to free context — `/compact <focus>` to steer it |
 | `/clear` | Reset conversation |
 | `/exit` | Quit |
 </details>

--- a/src/agent/compact.test.ts
+++ b/src/agent/compact.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import type { MiiMessage } from './types.js'
+
+const h = vi.hoisted(() => ({
+  reply: 'summary',
+  lastPrompt: '',
+  lastOpts: undefined as Record<string, unknown> | undefined,
+}))
+
+vi.mock('../llm/client.js', () => ({
+  chat: async function* (
+    _model: string,
+    messages: Array<{ content: string }>,
+    _tools: unknown,
+    opts?: Record<string, unknown>,
+  ) {
+    h.lastPrompt = messages[0].content
+    h.lastOpts = opts
+    yield { content: h.reply }
+  },
+}))
+
+const { compactHistory, estimateHistoryTokens, COMPACT_PREAMBLE } = await import('./compact.js')
+
+/** A summary long enough to clear the "model said nothing" guard. */
+const SUMMARY = '## Goal\nShip the thing.\n## Next steps\nWrite the tests properly.'
+
+function user(text: string): MiiMessage {
+  return { role: 'user', content: text }
+}
+function assistant(text: string): MiiMessage {
+  return { role: 'assistant', content: text }
+}
+/** An assistant turn calling a tool, plus the user message carrying its result. */
+function toolExchange(id: string): MiiMessage[] {
+  return [
+    { role: 'assistant', content: [{ type: 'tool_use', id, name: 'read_file', input: { path: 'a.ts' } }] },
+    { role: 'user', content: [{ type: 'tool_result', tool_use_id: id, content: 'file body' }] },
+  ]
+}
+
+beforeEach(() => {
+  h.reply = SUMMARY
+  h.lastPrompt = ''
+  h.lastOpts = undefined
+})
+
+describe('compactHistory', () => {
+  it('replaces history with the summary plus an acknowledgement', async () => {
+    const history = [user('build a parser'), assistant('done')]
+    const res = await compactHistory('m', history)
+
+    expect(res.summary).toBe(SUMMARY)
+    expect(res.history).toHaveLength(2)
+    expect(res.history[0].role).toBe('user')
+    expect(res.history[0].content).toBe(COMPACT_PREAMBLE + SUMMARY)
+    expect(res.history[1].role).toBe('assistant')
+    expect(res.droppedMessages).toBe(2)
+    expect(res.keptMessages).toBe(0)
+  })
+
+  it('keeps a recent tail verbatim when a context window is given', async () => {
+    const history = [
+      user('old task'),
+      assistant('old answer'),
+      user('new task'),
+      assistant('new answer'),
+    ]
+    const res = await compactHistory('m', history, { num_ctx: 8000 })
+
+    expect(res.keptMessages).toBeGreaterThan(0)
+    // At least half the history is always folded, so the recap has something to
+    // say; the tail begins at a real user turn, never mid-exchange.
+    expect(res.droppedMessages).toBeGreaterThan(0)
+    expect(res.history[2]).toEqual(user('new task'))
+    expect(res.history.at(-1)).toEqual(assistant('new answer'))
+  })
+
+  it('never cuts between a tool_use and its tool_result', async () => {
+    const history = [user('read it'), ...toolExchange('t1'), assistant('here it is')]
+    const res = await compactHistory('m', history, { num_ctx: 8000 })
+
+    const tail = res.history.slice(2)
+    // The only safe cut point is the leading user turn, so either the whole
+    // exchange survives or none of it does — a lone tool_result is a bug.
+    const orphan = tail.some(
+      (m) => Array.isArray(m.content) && m.content.some((b) => b.type === 'tool_result'),
+    )
+    if (orphan) expect(tail[0]).toEqual(user('read it'))
+  })
+
+  it('drops the tail when it cannot fit the budget', async () => {
+    const history = [user('x'.repeat(40000)), assistant('y'.repeat(40000))]
+    const res = await compactHistory('m', history, { num_ctx: 4096 })
+
+    expect(res.keptMessages).toBe(0)
+    expect(res.afterTokens).toBeLessThan(res.beforeTokens)
+  })
+
+  it('summarises tool calls and results rather than dropping them', async () => {
+    await compactHistory('m', [user('read it'), ...toolExchange('t1')])
+
+    expect(h.lastPrompt).toContain('read_file')
+    expect(h.lastPrompt).toContain('file body')
+  })
+
+  it('passes the focus instructions through to the model', async () => {
+    await compactHistory('m', [user('hi')], { instructions: 'the auth bug only' })
+    expect(h.lastPrompt).toContain('the auth bug only')
+  })
+
+  it('disables thinking so reasoning models emit a summary', async () => {
+    await compactHistory('m', [user('hi')])
+    expect(h.lastOpts?.think).toBe(false)
+  })
+
+  it('throws rather than returning an empty summary', async () => {
+    h.reply = '  '
+    await expect(compactHistory('m', [user('hi')])).rejects.toThrow(/empty summary/)
+  })
+
+  it('throws on empty history', async () => {
+    await expect(compactHistory('m', [])).rejects.toThrow(/nothing to compact/)
+  })
+})
+
+describe('estimateHistoryTokens', () => {
+  it('grows with the transcript and counts tool blocks', () => {
+    const small = estimateHistoryTokens([user('hi')])
+    const big = estimateHistoryTokens([user('hi'), ...toolExchange('t1')])
+    expect(big).toBeGreaterThan(small)
+  })
+})

--- a/src/agent/compact.ts
+++ b/src/agent/compact.ts
@@ -1,0 +1,209 @@
+/**
+ * Context compaction — summarise the conversation so far and continue.
+ *
+ * When the window fills up, the alternative to `/clear` is to trade the raw
+ * transcript for a recap of it: ask the model to write down what the session
+ * was doing, what it learned and what's left, then rebuild history as that
+ * recap plus the last verbatim turns. The session keeps going instead of
+ * starting over.
+ *
+ * The rebuilt history is always well-formed for the adapter: the tail can only
+ * start at a *real* user turn (one carrying no tool_result blocks), so a
+ * tool_use block can never be separated from the tool_result that answers it.
+ */
+import { chat } from '../llm/client.js'
+import type { MiiMessage, ContentBlock } from './types.js'
+
+/** Rough tokens-per-character; good enough for budgeting, never for billing. */
+const CHARS_PER_TOKEN = 4
+
+/** How much of the transcript we hand the summariser, in characters. */
+const TRANSCRIPT_BUDGET = 16000
+
+/** A single tool result rarely earns more than this in a recap. */
+const TOOL_RESULT_BUDGET = 400
+
+/** Share of the context window the preserved tail may occupy. */
+const TAIL_SHARE = 0.15
+
+/** Marks the recap in the rebuilt history so a resumed session reads right. */
+export const COMPACT_PREAMBLE =
+  'The earlier part of this conversation was removed to free up context. ' +
+  'Here is a summary of everything that happened before this point — treat it ' +
+  'as your own memory of the session and continue from it:\n\n'
+
+/** The canned acknowledgement that keeps the rebuilt history alternating. */
+const COMPACT_ACK =
+  'Understood — I have the summary of our work so far and will continue from there.'
+
+export function estimateTokens(text: string): number {
+  return Math.ceil(text.length / CHARS_PER_TOKEN)
+}
+
+/** Estimated prompt tokens for a whole history (text only — images excluded). */
+export function estimateHistoryTokens(history: MiiMessage[]): number {
+  let chars = 0
+  for (const m of history) chars += flatten(m).length
+  return Math.ceil(chars / CHARS_PER_TOKEN)
+}
+
+function truncate(text: string, max: number): string {
+  return text.length <= max ? text : `${text.slice(0, max)}… [${text.length - max} more chars]`
+}
+
+/** Flatten one message to the plain-text line(s) the summariser sees. */
+function flatten(m: MiiMessage): string {
+  const blocks: ContentBlock[] = Array.isArray(m.content)
+    ? m.content
+    : [{ type: 'text', text: m.content }]
+  const lines: string[] = []
+  for (const b of blocks) {
+    if (b.type === 'text') {
+      if (b.text.trim()) lines.push(`${m.role === 'user' ? 'User' : 'Assistant'}: ${b.text.trim()}`)
+    } else if (b.type === 'tool_use') {
+      lines.push(`Assistant called ${b.name}(${truncate(JSON.stringify(b.input ?? {}), 200)})`)
+    } else if (b.type === 'tool_result') {
+      const tag = b.is_error ? 'Tool error' : 'Tool result'
+      lines.push(`${tag}: ${truncate(b.content ?? '', TOOL_RESULT_BUDGET)}`)
+    }
+  }
+  return lines.join('\n')
+}
+
+/**
+ * Render history for the summariser, capped at `budget` characters. The opening
+ * of a session carries the task and the closing carries the current state, so a
+ * transcript that doesn't fit keeps a quarter of the head and the rest of the
+ * tail, with the drop marked in between.
+ */
+function renderTranscript(history: MiiMessage[], budget = TRANSCRIPT_BUDGET): string {
+  const full = history.map(flatten).filter(Boolean).join('\n')
+  if (full.length <= budget) return full
+  const head = Math.floor(budget * 0.25)
+  const tail = budget - head
+  return `${full.slice(0, head)}\n\n[… ${full.length - budget} characters of the middle omitted …]\n\n${full.slice(-tail)}`
+}
+
+/**
+ * A message is a "real" user turn if it's the person typing, not the harness
+ * feeding tool output back. Only these are safe places to cut history: cutting
+ * anywhere else can orphan a tool_use from its tool_result.
+ */
+function isUserTurn(m: MiiMessage): boolean {
+  if (m.role !== 'user') return false
+  if (typeof m.content === 'string') return true
+  return !m.content.some((b) => b.type === 'tool_result')
+}
+
+/**
+ * Index of the earliest real user turn whose tail fits in `tokenBudget`, or -1
+ * when nothing qualifies (the last exchange alone is already too big to keep).
+ *
+ * The search stops at the midpoint of the history: compaction that preserved
+ * everything would summarise an empty transcript and free nothing, so at least
+ * half the conversation always gets folded into the recap.
+ */
+function tailStart(history: MiiMessage[], tokenBudget: number): number {
+  const earliest = Math.max(1, Math.floor(history.length / 2))
+  let best = -1
+  for (let i = history.length - 1; i >= earliest; i--) {
+    if (!isUserTurn(history[i])) continue
+    if (estimateHistoryTokens(history.slice(i)) > tokenBudget) break
+    best = i
+  }
+  return best
+}
+
+function buildPrompt(transcript: string, instructions?: string): string {
+  const focus = instructions?.trim()
+    ? `\n\nThe user asked you to focus the summary on: ${instructions.trim()}`
+    : ''
+  return (
+    'You are compacting a coding session so it can continue in a fresh context ' +
+    'window. Write a summary that a competent engineer could pick the work up ' +
+    'from with no other information. Use these sections, in order, as markdown ' +
+    'headings:\n\n' +
+    '## Goal — what the user asked for, in their terms.\n' +
+    '## What happened — the work done so far, in order.\n' +
+    '## Files touched — paths, each with what changed and why.\n' +
+    '## Key facts — commands, APIs, conventions, constraints and decisions ' +
+    'discovered along the way that would be expensive to rediscover.\n' +
+    '## Current state — what is working, what is broken, what was just tried.\n' +
+    '## Next steps — the immediate remaining work.\n\n' +
+    'Be specific: exact paths, function names, commands and error text beat ' +
+    'summary prose. Omit a section only if it would be empty. Do not address ' +
+    'the user, do not add a preamble, and do not offer to help — output only ' +
+    `the summary.${focus}\n\n` +
+    `Here is the session transcript:\n\n${transcript}`
+  )
+}
+
+export interface CompactOptions {
+  /** Extra steer for the summary, from `/compact <instructions>`. */
+  instructions?: string
+  /** Context window in tokens; sizes both the request and the preserved tail. */
+  num_ctx?: number
+  signal?: AbortSignal
+}
+
+export interface CompactResult {
+  /** The recap the model wrote. */
+  summary: string
+  /** Rebuilt history: recap, acknowledgement, then the preserved tail. */
+  history: MiiMessage[]
+  /** How many messages were folded into the recap. */
+  droppedMessages: number
+  /** How many trailing messages survived verbatim. */
+  keptMessages: number
+  beforeTokens: number
+  afterTokens: number
+}
+
+/**
+ * Summarise `history` and rebuild it around the summary. Throws if the model
+ * returns nothing usable — the caller keeps the original history in that case,
+ * since a lost transcript is worse than a full one.
+ */
+export async function compactHistory(
+  model: string,
+  history: MiiMessage[],
+  opts: CompactOptions = {},
+): Promise<CompactResult> {
+  if (!history.length) throw new Error('nothing to compact')
+
+  const cut = opts.num_ctx ? tailStart(history, Math.floor(opts.num_ctx * TAIL_SHARE)) : -1
+  // Everything before the cut is what the summary has to stand in for; the tail
+  // survives verbatim, so summarising it again would just duplicate it.
+  const folded = cut === -1 ? history : history.slice(0, cut)
+  const tail = cut === -1 ? [] : history.slice(cut)
+
+  let out = ''
+  for await (const chunk of chat(
+    model,
+    [{ role: 'user', content: buildPrompt(renderTranscript(folded), opts.instructions) }],
+    undefined,
+    // No thinking: reasoning models otherwise spend the whole budget on hidden
+    // tokens and emit an empty summary — the same trap the titler hit.
+    { temperature: 0.2, num_predict: 1500, think: false, num_ctx: opts.num_ctx, signal: opts.signal },
+  )) {
+    if (chunk.content) out += chunk.content
+  }
+
+  const summary = out.trim()
+  if (summary.length < 40) throw new Error('the model returned an empty summary')
+
+  const rebuilt: MiiMessage[] = [
+    { role: 'user', content: COMPACT_PREAMBLE + summary },
+    { role: 'assistant', content: COMPACT_ACK },
+    ...tail,
+  ]
+
+  return {
+    summary,
+    history: rebuilt,
+    droppedMessages: folded.length,
+    keptMessages: tail.length,
+    beforeTokens: estimateHistoryTokens(history),
+    afterTokens: estimateHistoryTokens(rebuilt),
+  }
+}

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -18,12 +18,23 @@ import { SessionsView } from './SessionsView.js'
 import { CommandPalette } from './CommandPalette.js'
 import { persistSession, setSessionTitle, summarizeConversation, newSessionId, type SessionMeta } from '../session/store.js'
 import { setTerminalTitle, resetTerminalTitle } from './terminalTitle.js'
-import { enableMouse, disableMouse } from './mouse.js'
+import { enableMouse, disableMouse, isMouseEnabled, onMouseChange } from './mouse.js'
 import { FilePicker, parseMention, searchFiles } from './FilePicker.js'
 import { ChatView } from './ChatView.js'
 import { useAgentRunner } from './hooks/useAgentRunner.js'
 import { useKeyboard } from './hooks/useKeyboard.js'
 import { checkForUpdate, autoUpdate } from '../updateCheck.js'
+
+/** Warn the user once this share of the context window is in use. */
+const CONTEXT_WARN_AT = 0.7
+
+/**
+ * Compact automatically at this share. Deliberately below the hard limit: the
+ * summariser needs room to read the transcript and write the recap, and a turn
+ * that overflows mid-tool-call is a worse experience than one that pauses to
+ * compact itself.
+ */
+const AUTO_COMPACT_AT = 0.85
 
 type AppState = 'loading' | 'select-model' | 'ready' | 'models' | 'providers' | 'sessions'
 
@@ -92,6 +103,15 @@ export function App() {
   useEffect(() => {
     enableMouse()
     return disableMouse
+  }, [])
+
+  // ctrl+s hands the mouse back to the terminal so a drag selects text again;
+  // track it so the input bar can say the wheel has stopped scrolling. Synced on
+  // subscribe because the effect above has already switched reporting on by now.
+  const [mouseOn, setMouseOn] = useState(isMouseEnabled)
+  useEffect(() => {
+    setMouseOn(isMouseEnabled())
+    return onMouseChange(() => setMouseOn(isMouseEnabled()))
   }, [])
 
   // Ink recalculates its layout on resize but doesn't re-render the tree, so the
@@ -228,14 +248,23 @@ export function App() {
 
   const effort: Effort = cfg.effort ?? 'medium'
 
-  // Context usage warning threshold — warn when >= 70% of context window used.
-  const contextWarning = (() => {
-    if (!activeCtx) return null
-    const last = [...agent.messages].reverse().find((m) => m.role === 'assistant' && m.tokens)
-    const used = last?.tokens ? last.tokens.prompt_eval + last.tokens.eval : 0
-    if (used < activeCtx * 0.7) return null
-    return Math.round((used / activeCtx) * 100)
-  })()
+  // How full the context is, as a fraction. usedTokens is the runner's live
+  // reading — reported by the model after each turn, and corrected by
+  // compaction — so it drops the moment the history shrinks.
+  const contextPct = activeCtx && agent.usedTokens ? agent.usedTokens / activeCtx : 0
+  const contextWarning = contextPct >= CONTEXT_WARN_AT ? Math.round(contextPct * 100) : null
+
+  // Auto-compact when the window is nearly full, between turns. The ref latches
+  // so a compaction that fails (or one whose summary is still large) isn't
+  // retried on every render — it re-arms only once usage falls back under the
+  // threshold.
+  const autoCompacted = useRef(false)
+  useEffect(() => {
+    if (contextPct < AUTO_COMPACT_AT) { autoCompacted.current = false; return }
+    if (autoCompacted.current || agent.busy || state !== 'ready' || !cfg.model) return
+    autoCompacted.current = true
+    void agent.compact()
+  }, [contextPct, agent.busy, state, cfg.model])
 
   // Chat mode owns the whole screen: the root is pinned to the terminal height
   // (less one row, so writing the frame can't scroll it) and ChatView's viewport
@@ -326,7 +355,9 @@ export function App() {
           {state === 'ready' && contextWarning !== null && (
             <Box marginLeft={2} marginBottom={1} flexShrink={0}>
               <Text color="yellow">
-                {`⚠ context ${contextWarning}% full — run /clear and start fresh`}
+                {contextPct >= AUTO_COMPACT_AT
+                  ? `⚠ context ${contextWarning}% full — compacting automatically after this turn`
+                  : `⚠ context ${contextWarning}% full — /compact to summarize and keep going, /clear to start over`}
               </Text>
             </Box>
           )}
@@ -350,7 +381,13 @@ export function App() {
                 caret={caret}
                 disabled={agent.busy}
                 processingLabel={agent.processingLabel}
-                hint={providerDown ? 'provider unavailable — /provider to switch · /models to pick a model' : undefined}
+                hint={
+                  providerDown
+                    ? 'provider unavailable — /provider to switch · /models to pick a model'
+                    : mouseOn
+                      ? undefined
+                      : 'mouse off — drag to select and copy · ctrl+s to scroll with the wheel again'
+                }
               />
             </Box>
           )}

--- a/src/ui/InputBar.test.ts
+++ b/src/ui/InputBar.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { viewport, fieldWidth } from './InputBar.js'
+import { viewport, fieldWidth, fitHint } from './InputBar.js'
 
 describe('fieldWidth', () => {
   it('leaves room for the border, padding, prompt and scroll indicators', () => {
@@ -85,5 +85,21 @@ describe('viewport', () => {
       // (or the empty cell past the end).
       expect(v.text[v.caretCol] ?? '').toBe(input[caret] ?? '')
     }
+  })
+})
+
+describe('fitHint', () => {
+  it('leaves a hint that already fits alone', () => {
+    expect(fitHint('a · b', 80)).toBe('a · b')
+  })
+
+  it('drops whole segments from the right rather than wrapping', () => {
+    // width = 20 - 4 = 16 columns.
+    expect(fitHint('send · copy · select · scroll', 20)).toBe('send · copy')
+  })
+
+  it('truncates when even the first segment is too long', () => {
+    // 16 columns less the two paddings leaves 12, ellipsis included.
+    expect(fitHint('an extremely long single hint', 16)).toBe('an extremel…')
   })
 })

--- a/src/ui/InputBar.tsx
+++ b/src/ui/InputBar.tsx
@@ -33,6 +33,21 @@ export function fieldWidth(cols: number): number {
 }
 
 /**
+ * Fit the ` · `-separated hints into one row. A wrapped hint line grows the bar,
+ * which pushes the pinned frame past the terminal height — the same redraw the
+ * field's horizontal scrolling exists to avoid — so segments are dropped from
+ * the right until the line fits rather than being allowed to wrap.
+ */
+export function fitHint(hint: string, cols: number): string {
+  const width = Math.max(8, cols - 4) // outer padding (1 each side) + this box's (1 each side)
+  if (hint.length <= width) return hint
+  const parts = hint.split(' · ')
+  while (parts.length > 1 && parts.join(' · ').length > width) parts.pop()
+  const fitted = parts.join(' · ')
+  return fitted.length <= width ? fitted : `${fitted.slice(0, Math.max(1, width - 1))}…`
+}
+
+/**
  * A single-row window onto `input` that always contains the caret.
  *
  * The field must never wrap: this bar sits in Ink's live frame, and a bar that
@@ -130,7 +145,7 @@ export const InputBar = memo(function InputBar({
         )}
       </Box>
       <Box paddingX={1}>
-        <Text dimColor>{hint ?? (disabled ? BUSY_HINTS : INPUT_HINTS)}</Text>
+        <Text dimColor>{fitHint(hint ?? (disabled ? BUSY_HINTS : INPUT_HINTS), stdout?.columns ?? 80)}</Text>
       </Box>
     </Box>
   )

--- a/src/ui/clipboard.ts
+++ b/src/ui/clipboard.ts
@@ -95,6 +95,57 @@ function readWindows(out: string): string | null {
   return null
 }
 
+/**
+ * Copy text to the OS clipboard. Returns false when no clipboard writer is
+ * available, so the caller can say so rather than silently doing nothing.
+ *
+ * A terminal app can't reach the clipboard on its own: the selection the user
+ * would normally drag over is owned by the terminal, and miii's mouse reporting
+ * takes the drag before it gets there. So we shell out to the platform's
+ * clipboard tool, and fall back to OSC 52 — the escape sequence that asks the
+ * *terminal* to set the clipboard, which is the only thing that works over SSH.
+ */
+export function writeClipboardText(text: string): boolean {
+  if (!text) return false
+
+  const candidates: Array<readonly [string, readonly string[]]> =
+    process.platform === 'darwin'
+      ? [['pbcopy', []]]
+      : process.platform === 'win32'
+        ? [['clip', []], ['powershell', ['-NoProfile', '-NonInteractive', '-Command', '$input | Set-Clipboard']]]
+        : [['wl-copy', []], ['xclip', ['-selection', 'clipboard']], ['xsel', ['--clipboard', '--input']]]
+
+  for (const [cmd, args] of candidates) {
+    try {
+      execFileSync(cmd, [...args], { input: text, stdio: ['pipe', 'ignore', 'ignore'] })
+      return true
+    } catch { /* tool missing or refused the write — try the next one */ }
+  }
+
+  return writeOsc52(text)
+}
+
+/**
+ * Ask the terminal itself to set the clipboard (OSC 52). Emits no visible
+ * characters and doesn't move the cursor, so it can't disturb the frame Ink is
+ * painting. Terminals that don't support it — or have it switched off, as many
+ * do by default — ignore the sequence, which is why this is the last resort:
+ * there is no reply to tell us whether it landed.
+ */
+function writeOsc52(text: string): boolean {
+  if (!process.stdout.isTTY) return false
+  // Most terminals cap the sequence around 100KB; a truncated clipboard is
+  // worse than an honest failure.
+  const b64 = Buffer.from(text, 'utf8').toString('base64')
+  if (b64.length > 74994) return false
+  try {
+    process.stdout.write(`\x1b]52;c;${b64}\x07`)
+    return true
+  } catch {
+    return false
+  }
+}
+
 export function readClipboardImage(): string | null {
   const out = join(tmpdir(), `miii-clip-${Date.now()}-${Math.random().toString(36).slice(2)}.png`)
   if (process.platform === 'darwin') return readMac(out)

--- a/src/ui/constants.ts
+++ b/src/ui/constants.ts
@@ -15,12 +15,14 @@ export const COMMANDS: Command[] = [
   { name: '/provider', description: 'open provider picker (configured in ~/.miii/config.json)' },
   { name: '/new',    description: 'save current session and start fresh' },
   { name: '/sessions', description: 'list sessions and resume one' },
+  { name: '/copy',   description: 'copy to clipboard · /copy last | code | tool | all' },
+  { name: '/compact', description: 'summarize the conversation to free context · /compact <focus>' },
   { name: '/clear',  description: 'clear chat and reset context' },
   { name: '/exit',   description: 'quit miii' },
 ]
 
 /** Commands featured on the welcome card, in display order. */
-const WELCOME_COMMAND_NAMES = ['/models', '/sessions', '/new', '/clear']
+const WELCOME_COMMAND_NAMES = ['/models', '/sessions', '/new', '/copy', '/compact', '/clear']
 
 /** The featured commands, resolved against COMMANDS so copy never drifts. */
 export const WELCOME_COMMANDS: Command[] = WELCOME_COMMAND_NAMES.flatMap(
@@ -33,7 +35,7 @@ export const WELCOME_PROMPT = 'To get started, describe a task or try one of the
 export const INPUT_PLACEHOLDER = 'describe a task, or type / for commands'
 
 /** Key hints under the input bar. Kept short — they share one line. */
-export const INPUT_HINTS = '⏎ send · / commands · @ file · ctrl+t thinking · scroll or pgup/pgdn to look back'
+export const INPUT_HINTS = '⏎ send · / commands · @ file · ctrl+y copy · ctrl+s select · scroll or pgup/pgdn to look back'
 
 /** Key hints under the input bar while a turn is running. */
-export const BUSY_HINTS = 'esc interrupt · click or ctrl+o expand tool output · scroll to look back'
+export const BUSY_HINTS = 'esc interrupt · click or ctrl+o expand tool output · ctrl+y copy · scroll to look back'

--- a/src/ui/copy.test.ts
+++ b/src/ui/copy.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest'
+import { collectCopyText, codeBlocks, describeSize, parseCopyTarget } from './copy.js'
+import type { ChatMessage } from './types.js'
+
+const user = (content: string): ChatMessage => ({ role: 'user', content })
+const reply = (content: string): ChatMessage => ({ role: 'assistant', content })
+
+describe('parseCopyTarget', () => {
+  it('defaults a bare /copy to the last reply', () => {
+    expect(parseCopyTarget('')).toBe('last')
+    expect(parseCopyTarget('  ')).toBe('last')
+  })
+
+  it('accepts aliases, case-insensitively', () => {
+    expect(parseCopyTarget('Reply')).toBe('last')
+    expect(parseCopyTarget('OUTPUT')).toBe('tool')
+    expect(parseCopyTarget('chat')).toBe('all')
+  })
+
+  it('rejects anything else', () => {
+    expect(parseCopyTarget('everything')).toBeNull()
+  })
+})
+
+describe('codeBlocks', () => {
+  it('extracts fenced blocks without the fences or info string', () => {
+    const md = 'before\n```ts\nconst a = 1\n```\nafter\n```\nplain\n```'
+    expect(codeBlocks(md)).toEqual(['const a = 1', 'plain'])
+  })
+
+  it('ignores empty fences', () => {
+    expect(codeBlocks('```\n\n```')).toEqual([])
+  })
+})
+
+describe('collectCopyText', () => {
+  const messages: ChatMessage[] = [
+    user('read the file'),
+    {
+      role: 'assistant',
+      content: 'here it is',
+      tool_uses: [{ id: 't1', name: 'read_file', input: { path: 'a.ts' } }],
+      tool_results: [{ tool_use_id: 't1', content: 'file body' }],
+    },
+    reply('done — try:\n```sh\nnpm test\n```'),
+  ]
+
+  it('copies the last reply', () => {
+    expect(collectCopyText(messages, 'last')).toBe('done — try:\n```sh\nnpm test\n```')
+  })
+
+  it('copies the last code block, unfenced', () => {
+    expect(collectCopyText(messages, 'code')).toBe('npm test')
+  })
+
+  it('copies the most recent tool output, skipping turns without one', () => {
+    expect(collectCopyText(messages, 'tool')).toBe('file body')
+  })
+
+  it('copies the whole conversation with tool output inline', () => {
+    const all = collectCopyText(messages, 'all')!
+    expect(all).toContain('> read the file')
+    expect(all).toContain('miii: here it is')
+    expect(all).toContain('[tool output]\nfile body')
+  })
+
+  it('returns null when the target is not there', () => {
+    expect(collectCopyText([], 'last')).toBeNull()
+    expect(collectCopyText([], 'all')).toBeNull()
+    expect(collectCopyText(messages.slice(0, 1), 'tool')).toBeNull()
+    expect(collectCopyText([reply('no code here')], 'code')).toBeNull()
+  })
+
+  it('skips an empty streamed reply when picking the last one', () => {
+    expect(collectCopyText([reply('real answer'), reply('   ')], 'last')).toBe('real answer')
+  })
+})
+
+describe('describeSize', () => {
+  it('singularises one line', () => {
+    expect(describeSize('one')).toBe('1 line')
+    expect(describeSize('one\ntwo')).toBe('2 lines')
+  })
+})

--- a/src/ui/copy.ts
+++ b/src/ui/copy.ts
@@ -1,0 +1,103 @@
+/**
+ * copy — turn the transcript into text for the clipboard.
+ *
+ * The rendered transcript is Ink's, not the terminal's: it lives in miii's own
+ * viewport, is repainted on every frame, and the mouse drag that would select
+ * it is taken by mouse reporting. So instead of fighting for the selection,
+ * `/copy` (and ctrl+y) lift the underlying text straight out of the message
+ * log, which also means the copy is clean — no wrapping, no gutters, no
+ * truncated tool output.
+ */
+import type { ChatMessage } from './types.js'
+
+export type CopyTarget = 'last' | 'all' | 'code' | 'tool'
+
+const TARGETS: Record<string, CopyTarget> = {
+  '': 'last',
+  last: 'last',
+  reply: 'last',
+  all: 'all',
+  chat: 'all',
+  code: 'code',
+  tool: 'tool',
+  output: 'tool',
+}
+
+/** Parse the `/copy` argument; null for anything we don't recognise. */
+export function parseCopyTarget(arg: string): CopyTarget | null {
+  return TARGETS[arg.trim().toLowerCase()] ?? null
+}
+
+/** Human name for a target, for notices. */
+export function describeTarget(target: CopyTarget): string {
+  return target === 'last'
+    ? 'last reply'
+    : target === 'all'
+      ? 'conversation'
+      : target === 'code'
+        ? 'last code block'
+        : 'last tool output'
+}
+
+/**
+ * Fenced code blocks in a markdown string, in order. The info string (```ts) is
+ * dropped — what gets pasted is the code, not the fence.
+ */
+export function codeBlocks(markdown: string): string[] {
+  const out: string[] = []
+  const re = /```[^\n]*\n([\s\S]*?)```/g
+  let m: RegExpExecArray | null
+  while ((m = re.exec(markdown)) !== null) {
+    const body = m[1].replace(/\n$/, '')
+    if (body.trim()) out.push(body)
+  }
+  return out
+}
+
+/** The whole conversation as plain text, speakers labelled. */
+function wholeConversation(messages: ChatMessage[]): string {
+  const parts: string[] = []
+  for (const m of messages) {
+    const body = m.content.trim()
+    if (body) parts.push(`${m.role === 'user' ? '>' : 'miii:'} ${body}`)
+    for (const r of m.tool_results ?? []) {
+      if (r.content.trim()) parts.push(`[${r.is_error ? 'error' : 'tool output'}]\n${r.content.trim()}`)
+    }
+  }
+  return parts.join('\n\n')
+}
+
+/**
+ * The text `target` refers to, or null when there isn't any — an empty
+ * transcript, a reply with no code in it, a session with no tool output yet.
+ */
+export function collectCopyText(messages: ChatMessage[], target: CopyTarget): string | null {
+  if (target === 'all') return wholeConversation(messages) || null
+
+  if (target === 'tool') {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const results = messages[i].tool_results
+      if (!results?.length) continue
+      // The last result of the last turn that ran tools — the one on screen.
+      const text = results[results.length - 1].content.trim()
+      if (text) return text
+    }
+    return null
+  }
+
+  const lastReply = [...messages].reverse().find((m) => m.role === 'assistant' && m.content.trim())
+  if (!lastReply) return null
+
+  if (target === 'code') {
+    const blocks = codeBlocks(lastReply.content)
+    return blocks.length ? blocks[blocks.length - 1] : null
+  }
+
+  return lastReply.content.trim()
+}
+
+/** "3 lines" / "1 line" — the unit a notice quotes back after a copy. */
+export function describeSize(text: string): string {
+  const lines = text.split('\n').length
+  return `${lines} line${lines === 1 ? '' : 's'}`
+}

--- a/src/ui/hooks/useAgentRunner.ts
+++ b/src/ui/hooks/useAgentRunner.ts
@@ -6,6 +6,7 @@
  */
 import { useState, useRef } from 'react'
 import { runAgent } from '../../agent/loop.js'
+import { compactHistory, estimateHistoryTokens } from '../../agent/compact.js'
 import type { ChatMessage, PermissionRequest, PermissionAnswer, ToolUseDisplay, ToolResultDisplay } from '../types.js'
 import type { MiiMessage } from '../../agent/types.js'
 import { tailLine } from '../layout.js'
@@ -27,6 +28,14 @@ export function useAgentRunner(model: string | undefined, activeCtx: number | nu
   const [permissionCursor, setPermissionCursor] = useState(0)
   const [activeToolUses, setActiveToolUses] = useState<ToolUseDisplay[]>([])
   const [activeToolResults, setActiveToolResults] = useState<ToolResultDisplay[]>([])
+  /**
+   * Prompt+eval tokens the model reported for the last turn — i.e. how full the
+   * context is right now. Kept as state rather than derived from the transcript
+   * so compaction can correct it immediately; a stale reading there would have
+   * the auto-compact trigger fire again the moment it finished.
+   */
+  const [usedTokens, setUsedTokens] = useState(0)
+  const [compacting, setCompacting] = useState(false)
 
   const busyRef = useRef(false)
   const abortRef = useRef<AbortController | null>(null)
@@ -204,10 +213,12 @@ export function useAgentRunner(model: string | undefined, activeCtx: number | nu
           }
           case 'done': {
             finalTokens = { prompt: ev.prompt_tokens, eval: ev.eval_tokens }
+            setUsedTokens(ev.prompt_tokens + ev.eval_tokens)
             break
           }
           case 'aborted': {
             finalTokens = { prompt: ev.prompt_tokens, eval: ev.eval_tokens }
+            setUsedTokens(ev.prompt_tokens + ev.eval_tokens)
             setStreaming(false)
             setThinking(false)
             flushTurn(finalTokens)
@@ -239,6 +250,63 @@ export function useAgentRunner(model: string | undefined, activeCtx: number | nu
     setProcessingLabel(undefined)
   }
 
+  /**
+   * Fold the conversation into a summary and keep going — the alternative to
+   * /clear when the window fills up. The visible transcript is left alone (it's
+   * the user's record of the session); what shrinks is the history the model is
+   * sent, so the summary lands in the transcript as its own entry.
+   *
+   * Resolves false when it couldn't run or the model failed to summarise; the
+   * original history is untouched in that case, since a full context is a far
+   * better problem than a lost one.
+   */
+  async function compact(instructions?: string): Promise<boolean> {
+    if (busyRef.current || !model) return false
+    if (!agentHistory.length) {
+      setError('nothing to compact yet — the conversation is empty')
+      return false
+    }
+    busyRef.current = true
+    setBusy(true)
+    setCompacting(true)
+    setProcessingLabel('compacting context…')
+    setError(null)
+
+    const controller = new AbortController()
+    abortRef.current = controller
+
+    try {
+      const res = await compactHistory(model, agentHistory, {
+        instructions,
+        num_ctx: activeCtx ?? undefined,
+        signal: controller.signal,
+      })
+      setAgentHistory(res.history)
+      setUsedTokens(estimateHistoryTokens(res.history))
+      const kept = res.keptMessages ? `, last ${res.keptMessages} kept verbatim` : ''
+      setMessages((prev) => [
+        ...prev,
+        {
+          role: 'assistant',
+          content:
+            `⧉ **context compacted** — ${res.droppedMessages} messages summarised${kept}. ` +
+            `~${res.beforeTokens} → ~${res.afterTokens} tokens.\n\n${res.summary}`,
+        },
+      ])
+      return true
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      setError(controller.signal.aborted ? 'Compaction cancelled — context unchanged' : `Compaction failed: ${msg}`)
+      return false
+    } finally {
+      abortRef.current = null
+      busyRef.current = false
+      setBusy(false)
+      setCompacting(false)
+      setProcessingLabel(undefined)
+    }
+  }
+
   return {
     // state
     messages, setMessages,
@@ -254,6 +322,8 @@ export function useAgentRunner(model: string | undefined, activeCtx: number | nu
     permissionCursor, setPermissionCursor,
     activeToolUses, setActiveToolUses,
     activeToolResults, setActiveToolResults,
+    usedTokens, setUsedTokens,
+    compacting,
     // refs (for keyboard handler)
     busyRef,
     abortRef,
@@ -262,5 +332,6 @@ export function useAgentRunner(model: string | undefined, activeCtx: number | nu
     sendMessage,
     resolvePermission,
     cancelPermission,
+    compact,
   }
 }

--- a/src/ui/hooks/useKeyboard.ts
+++ b/src/ui/hooks/useKeyboard.ts
@@ -8,13 +8,14 @@ import { existsSync, readFileSync } from 'fs'
 import { basename, join } from 'path'
 import { homedir } from 'os'
 import { useInput, useStdout } from 'ink'
-import { readClipboardImage } from '../clipboard.js'
+import { readClipboardImage, writeClipboardText } from '../clipboard.js'
+import { collectCopyText, describeSize, describeTarget, parseCopyTarget, type CopyTarget } from '../copy.js'
 import { setModel, setEffort, type NamedProvider, type Provider, type Effort } from '../../config.js'
 import { filteredCommands } from '../CommandPalette.js'
 import { invalidateFileCache, parseMention, searchFiles } from '../FilePicker.js'
 import { toggleThinkingVisible } from '../ThinkingBlock.js'
 import { toggleToolExpanded } from '../toolExpand.js'
-import { parseMouseEvents } from '../mouse.js'
+import { parseMouseEvents, toggleMouse } from '../mouse.js'
 import { scrollBy, scrollToBottom, resetScroll } from '../scroll.js'
 import { setTerminalTitle, resetTerminalTitle } from '../terminalTitle.js'
 import {
@@ -26,6 +27,7 @@ import {
   newSessionId,
   type SessionMeta,
 } from '../../session/store.js'
+import { estimateHistoryTokens } from '../../agent/compact.js'
 import type { useAgentRunner } from './useAgentRunner.js'
 
 const EFFORTS: Effort[] = ['low', 'medium', 'high']
@@ -210,8 +212,8 @@ export function useKeyboard(opts: KeyboardOptions) {
   const {
     pendingPermissionRef, permissionCursor, setPermissionCursor, resolvePermission, cancelPermission,
     busyRef, abortRef,
-    sendMessage, agentHistory, setMessages, setAgentHistory, setStreamingContent, setThinkingTail,
-    setActiveToolUses, setActiveToolResults, setError,
+    sendMessage, compact, messages, agentHistory, setMessages, setAgentHistory, setStreamingContent, setThinkingTail,
+    setActiveToolUses, setActiveToolResults, setError, setUsedTokens,
   } = agent
 
   const { write } = useStdout()
@@ -231,6 +233,7 @@ export function useKeyboard(opts: KeyboardOptions) {
   function clearSession() {
     setMessages(() => [])
     setAgentHistory([])
+    setUsedTokens(0)
     setStreamingContent('')
     setThinkingTail('')
     setActiveToolUses([])
@@ -242,6 +245,24 @@ export function useKeyboard(opts: KeyboardOptions) {
     // Remount the transcript so its measured height restarts from the empty log
     // instead of the heights Ink last laid out.
     setLogEpoch((n) => n + 1)
+  }
+
+  /**
+   * Put part of the transcript on the system clipboard and report what happened.
+   * Reads the message log rather than the screen, so the copy is the real text —
+   * no wrapping, no gutter, no truncated tool output.
+   */
+  function copyToClipboard(target: CopyTarget) {
+    const text = collectCopyText(messages, target)
+    if (!text) {
+      setNotice(`nothing to copy — no ${describeTarget(target)} yet`)
+      return
+    }
+    setNotice(
+      writeClipboardText(text)
+        ? `copied ${describeTarget(target)} · ${describeSize(text)}`
+        : 'no clipboard tool found — install pbcopy/wl-copy/xclip, or ctrl+s to select with the mouse',
+    )
   }
 
   const effort: Effort = cfg.effort ?? 'medium'
@@ -280,6 +301,20 @@ export function useKeyboard(opts: KeyboardOptions) {
     if (key.ctrl && char === 't') { toggleThinkingVisible(); return }
     // Ctrl+O toggles full tool output (collapsed to a few lines by default)
     if (key.ctrl && char === 'o') { toggleToolExpanded(); return }
+    // Ctrl+Y yanks the last reply to the clipboard — /copy for anything else.
+    if (key.ctrl && char === 'y') { copyToClipboard('last'); return }
+    // Ctrl+S hands the mouse back to the terminal so a drag selects text again.
+    // The wheel stops scrolling the transcript while it's off (pgup/pgdn still
+    // do), which is the trade the notice spells out.
+    if (key.ctrl && char === 's') {
+      const on = toggleMouse()
+      setNotice(
+        on
+          ? 'mouse on — wheel scrolls the transcript'
+          : 'mouse off — drag to select and copy · ctrl+s to scroll again',
+      )
+      return
+    }
 
     if (key.escape && busyRef.current && abortRef.current) {
       // Settle a permission prompt that's waiting on the user before aborting.
@@ -384,6 +419,7 @@ export function useKeyboard(opts: KeyboardOptions) {
         const meta = sessions[cursor]
         const history = loadSession(meta.id)
         setAgentHistory(history)
+        setUsedTokens(estimateHistoryTokens(history))
         setMessages(toDisplayMessages(history))
         setStreamingContent('')
         setThinkingTail('')
@@ -505,6 +541,17 @@ export function useKeyboard(opts: KeyboardOptions) {
           setPickerQuery('')
           setCursor(() => Math.max(0, providers.findIndex((p) => p.name === cfg.provider)))
           setState('providers')
+        } else if (trimmed === '/copy' || trimmed.startsWith('/copy ')) {
+          const arg = trimmed.slice('/copy'.length).trim()
+          const target = parseCopyTarget(arg)
+          if (target) copyToClipboard(target)
+          else setNotice(`unknown /copy target "${arg}" — try last, code, tool or all`)
+        } else if (trimmed === '/compact' || trimmed.startsWith('/compact ')) {
+          // Summarise and carry on rather than starting over. The transcript is
+          // left on screen; only the history sent to the model shrinks.
+          const instructions = trimmed.slice('/compact'.length).trim()
+          setNotice(null)
+          void compact(instructions || undefined)
         } else if (trimmed === '/clear') {
           hardClear()
           clearSession()

--- a/src/ui/mouse.ts
+++ b/src/ui/mouse.ts
@@ -7,6 +7,10 @@
  * the terminal keeps as much native behaviour as it can — drag-to-select still
  * works with the usual override (option-drag on macOS, shift-drag elsewhere).
  *
+ * Reporting can be switched off from the app (ctrl+s), which hands the mouse
+ * back to the terminal so a plain drag selects text again — the one thing an
+ * app that owns the mouse takes away, and the reason /copy exists too.
+ *
  * Reports arrive on stdin as `ESC [ < b ; x ; y M|m`. Ink's parse-keypress
  * leaves them intact and strips only the leading ESC, so the keyboard handler
  * matches them with parseMouseEvents() and swallows them before they can reach
@@ -41,17 +45,39 @@ export type MouseEvent = {
 }
 
 let enabled = false
+// Notified whenever reporting is switched on or off, so the UI can say which
+// mode it's in without threading the flag through the component tree.
+const listeners = new Set<() => void>()
+
+export function isMouseEnabled(): boolean {
+  return enabled
+}
+
+function setMouse(on: boolean): void {
+  if (on === enabled || !process.stdout.isTTY) return
+  enabled = on
+  process.stdout.write(on ? ENABLE : DISABLE)
+  listeners.forEach((fn) => fn())
+}
 
 export function enableMouse(): void {
-  if (enabled || !process.stdout.isTTY) return
-  enabled = true
-  process.stdout.write(ENABLE)
+  setMouse(true)
 }
 
 export function disableMouse(): void {
-  if (!enabled) return
-  enabled = false
-  if (process.stdout.isTTY) process.stdout.write(DISABLE)
+  setMouse(false)
+}
+
+/** Flip reporting; returns the new state. */
+export function toggleMouse(): boolean {
+  setMouse(!enabled)
+  return enabled
+}
+
+/** Subscribe to reporting changes; returns the unsubscribe. */
+export function onMouseChange(fn: () => void): () => void {
+  listeners.add(fn)
+  return () => { listeners.delete(fn) }
 }
 
 function toEvent(b: string, x: string, y: string, end: string): MouseEvent {


### PR DESCRIPTION
Two things a full or unselectable transcript made impossible.

Compaction. A full context window offered only "run /clear and start fresh" — throw the session away. /compact instead asks the model for a structured recap (goal, what happened, files touched, key facts, current state, next steps) and rebuilds history as that recap plus the most recent turns kept verbatim; the session carries on. It also runs on its own at 85% of the window, between turns, so a turn can't overflow mid-tool-call.

The rebuilt history is always well-formed for the adapter: the preserved tail can only start at a real user turn (one carrying no tool_result blocks), so a tool_use is never orphaned from the result that answers it. At least half the conversation is always folded in, or the recap would summarise nothing and free nothing. A model that returns no usable summary leaves the original history untouched — a full context is a far better problem than a lost one.

Context usage moves into useAgentRunner as state rather than being re-derived from the last assistant message's token count: that reading is stale immediately after a compaction, which would have had the auto-compact trigger fire again the moment it finished.

Copying. miii turns on mouse reporting so the wheel scrolls the transcript, which means the terminal hands a drag to the app instead of using it to select text. Ctrl+S now gives the mouse back, and the input bar says the wheel has stopped scrolling while it's off. Ctrl+Y and /copy (last | code | tool | all) go the other way and write to the clipboard directly — better than selecting, since they lift the text out of the message log rather than the screen: no wrapping, no gutters, and collapsed tool output copies in full. pbcopy / wl-copy / xclip / xsel / clip, falling back to OSC 52 for SSH.

Also clamps the input bar's hint line to the terminal width. It had no clamp, so the longer hints would wrap and add a row to the pinned frame — the redraw the field's horizontal scrolling exists to avoid.