### PR TITLE
feat: plan mode, custom slash commands, project-scoped permissions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@
 *.log
 .DS_Store
 .claude
-.miii
+.miii/permissions.json
+.miii/output
 .vitest-*

--- a/README.md
+++ b/README.md
@@ -59,7 +59,9 @@ miii reads your files, writes the code, runs your tests, and fixes what breaks �
 - **🧪 `miii doctor`** — not every local model can drive an agent. Grades your installed models on real engineering tasks.
 - **🖼️ Paste images** — `Ctrl+V` a screenshot to ask why a UI looks broken. Needs a vision model (`llava`, `llama3.2-vision`, …).
 - **💧 Lossless output spill** — a 50K-line test log is never truncated. The full text goes to disk and the model pages through it.
+- **📋 Plan mode** — `shift+tab` (or `/plan`) makes the session read-only. miii researches your code, proposes a plan, and touches nothing until you approve it. The block is enforced by the harness, not asked for in the prompt: with no write tools and only reporting commands, a model that tries `sed -i` or `cat > file` anyway gets refused.
 - **🔒 Permission-gated tools** — you approve what the agent touches, and see the exact rule before you save it. A saved wildcard never stretches across a command boundary, so approving `npm test` can't quietly authorize `npm test && rm -rf ~`.
+- **⌨️ Your own slash commands** — drop `review.md` in `.miii/commands/` and `/review` is a command, in the palette, checked into the repo with everything else.
 - **📄 `MIII.md`** — drop one in your repo to teach miii your conventions and commands. Same idea as `CLAUDE.md`, read every turn.
 
 **Picking a model:** 8GB VRAM → `qwen2.5-coder:7b` · 16–24GB → `qwen2.5-coder:14b` (sweet spot) · 48GB+ → `qwen2.5-coder:32b`.
@@ -89,7 +91,41 @@ Answering "always" saves both the exact command and a generalized glob (`npm run
 
 Two things are never widened: destructive programs (`rm`, `dd`, `sudo`, `git reset`, …) and compound commands, whose first token says nothing about what the rest of the line does. A saved glob also refuses to match any command containing an unquoted `;` `&&` `||` `|` `>` or `$(…)`, so an approval can't be stretched past the command you actually read.
 
-Saved rules live in `~/.miii/permissions.json`.
+Saved rules live in **`.miii/permissions.json` in the project** — that is what "always" writes to. Approval subjects are usually project-relative (`src/index.ts` means a different file in every repo), so a rule that followed you everywhere would be granting far more than you agreed to. Rules in `~/.miii/permissions.json` apply in every project; put the ones you really do mean globally there by hand. `/permissions` lists both and says which file each came from.
+
+Gitignore `.miii/permissions.json` — it is a record of what *you* approved. `.miii/commands/` is meant to be committed.
+</details>
+
+<details>
+<summary><strong>Permission modes</strong> — <code>shift+tab</code></summary>
+
+`shift+tab` cycles the mode; the input frame changes colour with it.
+
+| Mode | What it does |
+|------|--------------|
+| **normal** | asks before writing files or running commands |
+| **plan mode** | read-only — research and a plan, approved before anything happens |
+| **auto-accept edits** | writes files without asking; commands still prompt, since a command can reach outside the workspace |
+| **bypass permissions** | runs everything without asking (red frame — for a sandbox or a throwaway tree) |
+
+In **plan mode** the write tools are not offered at all and `run_bash` runs only commands that report — `ls`, `cat`, `grep`, `find`, `git status/log/diff`, one at a time, no pipes or `&&`. A compound command is refused however harmless its first word, because `ls` tells you nothing about what comes after the `&&`. When the research is done miii calls `exit_plan_mode` with the plan and you get three choices: start work, start work and stop asking about the edits, or send it back for another pass.
+</details>
+
+<details>
+<summary><strong>Custom slash commands</strong></summary>
+
+A Markdown file is a command. `.miii/commands/review.md` becomes `/review`:
+
+```markdown
+---
+description: review the staged diff
+---
+Review the staged diff for bugs and unhandled errors. Focus on $ARGUMENTS.
+```
+
+`$ARGUMENTS` is everything typed after the command; `$1`…`$9` are its individual words. A command that references neither gets the arguments appended, so nothing you type is silently dropped.
+
+`.miii/commands/` is project scope — check it in, and the whole team gets it. `~/.miii/commands/` is yours in every project. A project command shadows a personal one of the same name, and neither can shadow a built-in.
 </details>
 
 <details>
@@ -99,6 +135,7 @@ Saved rules live in `~/.miii/permissions.json`.
 |-----|--------|
 | `Enter` | Send prompt |
 | `/` | Open the command palette |
+| `Shift+Tab` | Cycle permission mode — normal → plan → auto-accept → bypass |
 | `@filename` | Attach file to context |
 | `Ctrl+V` | Paste clipboard image (needs a vision model) |
 | `Ctrl+T` | Toggle the model's thinking |
@@ -114,6 +151,8 @@ Saved rules live in `~/.miii/permissions.json`.
 
 | Command | Action |
 |---------|--------|
+| `/plan` | Toggle plan mode — research read-only, then approve the plan |
+| `/permissions` | List saved approval rules and which file each lives in |
 | `/models` | Switch model, provider (`tab`) and effort (`←→`) |
 | `/provider` | Pick a configured provider |
 | `/new` | Save this session and start fresh |
@@ -186,7 +225,8 @@ src/
  ├── agent/       # The core reasoning loop, and tool-call repair
  ├── tools/       # read/write/edit/bash/grep/glob/todos + output spill
  ├── prompt/      # System prompt and MIII.md project context
- ├── permissions/ # Approval rules and how they're scoped
+ ├── permissions/ # Approval rules, modes, and how they're scoped
+ ├── commands/    # User-defined slash commands (.miii/commands/*.md)
  ├── llm/         # Ollama and OpenAI-compatible backends
  ├── session/     # Saved conversations
  ├── ui/          # Ink terminal UI and input handling

--- a/src/agent/loop.test.ts
+++ b/src/agent/loop.test.ts
@@ -47,7 +47,10 @@ vi.mock('../llm/client.js', () => ({
   },
 }))
 
-const KNOWN = ['echo', 'run_bash']
+const KNOWN = ['echo', 'run_bash', 'read_file', 'edit_file', 'write_file', 'exit_plan_mode']
+// What the real registry advertises while planning — mirrored here so the
+// loop's plan enforcement is exercised against the same set it ships with.
+const PLAN_TOOLS = ['read_file', 'run_bash', 'exit_plan_mode']
 function makeTool(name: string) {
   return {
     name,
@@ -63,6 +66,8 @@ vi.mock('../tools/registry.js', () => ({
   TOOLS: [makeTool('echo'), makeTool('run_bash')],
   getTool: (name: string) => (KNOWN.includes(name) ? makeTool(name) : undefined),
   toOllamaTools: () => [],
+  toolsForMode: (mode: string) =>
+    (mode === 'plan' ? PLAN_TOOLS : ['echo', 'run_bash']).map(makeTool),
 }))
 
 vi.mock('../tools/validate.js', () => ({
@@ -72,7 +77,10 @@ vi.mock('../tools/validate.js', () => ({
 
 vi.mock('../prompt/system.js', () => ({ buildSystemPrompt: () => 'SYS' }))
 vi.mock('../prompt/context.js', () => ({ loadProjectContext: () => '' }))
-vi.mock('../permissions/policy.js', () => ({
+// Only check() is faked. isReadOnlyCommand is a pure classifier with no I/O,
+// and plan mode's whole boundary rests on it — a stub here would test the stub.
+vi.mock('../permissions/policy.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../permissions/policy.js')>()),
   check: async () => {
     h.checkCalls++
     h.onCheck?.()
@@ -467,5 +475,135 @@ describe('near-miss tool calls', () => {
     const r = firstResults(history)[0]
     expect(r.is_error).toBe(true)
     expect(r.content).toContain('Unknown tool')
+  })
+})
+
+// ---- plan mode -----------------------------------------------------------
+
+/**
+ * A permissions context whose `ask` always answers the same way, recording how
+ * many times it was consulted. Plan approval goes through `ask` directly rather
+ * than through check(), so these two counters distinguish the paths.
+ */
+function asker(answer: 'yes' | 'no' | 'always') {
+  const calls: string[] = []
+  return {
+    calls,
+    permissions: {
+      ask: async (toolName: string) => {
+        calls.push(toolName)
+        return answer
+      },
+    } as never,
+  }
+}
+
+/** Did the run execute this tool's handler? */
+function ranTool(name: string, ran: string[]): boolean {
+  return ran.includes(name)
+}
+
+describe('plan mode', () => {
+  it('refuses a tool it never advertised, and points at exit_plan_mode', async () => {
+    const ran: string[] = []
+    h.toolHandlers.echo = () => { ran.push('echo'); return { content: 'ok' } }
+    h.script = [toolThenDone([call('echo', { a: 1 })]), textThenDone('ok')]
+
+    const { history } = await drive({ mode: 'plan', ...asker('yes') })
+    const r = firstResults(history)[0]
+
+    expect(r.is_error).toBe(true)
+    expect(r.content).toContain('read-only')
+    expect(r.content).toContain('exit_plan_mode')
+    // The point of the guard: the handler must not have run.
+    expect(ranTool('echo', ran)).toBe(false)
+    assertBlockOrdering(history)
+  })
+
+  it('runs a command that only reports', async () => {
+    const ran: string[] = []
+    h.toolHandlers.run_bash = () => { ran.push('run_bash'); return { content: 'a.ts' } }
+    h.script = [toolThenDone([call('run_bash', { command: 'ls src' })]), textThenDone('ok')]
+
+    const { history } = await drive({ mode: 'plan', ...asker('yes') })
+    expect(firstResults(history)[0].is_error).toBeFalsy()
+    expect(ranTool('run_bash', ran)).toBe(true)
+  })
+
+  it('refuses a command that writes, and one that smuggles a write past a &&', async () => {
+    for (const command of ['rm -rf build', 'ls && rm -rf build', 'cat a > b']) {
+      h.callIndex = 0
+      const ran: string[] = []
+      h.toolHandlers.run_bash = () => { ran.push('run_bash'); return { content: 'ok' } }
+      h.script = [toolThenDone([call('run_bash', { command })]), textThenDone('ok')]
+
+      const { history } = await drive({ mode: 'plan', ...asker('yes') })
+      const r = firstResults(history)[0]
+      expect(r.is_error, command).toBe(true)
+      expect(r.content, command).toContain('only commands that report')
+      expect(ranTool('run_bash', ran), command).toBe(false)
+    }
+  })
+
+  it('approving a plan leaves plan mode and unblocks the rest of the run', async () => {
+    const ran: string[] = []
+    h.toolHandlers.run_bash = () => { ran.push('run_bash'); return { content: 'ok' } }
+    h.script = [
+      toolThenDone([call('exit_plan_mode', { plan: '1. delete build/' })]),
+      // Refused a turn ago; allowed now, which is the whole assertion.
+      toolThenDone([call('run_bash', { command: 'rm -rf build' })]),
+      textThenDone('done'),
+    ]
+
+    const { events, history } = await drive({ mode: 'plan', ...asker('yes') })
+
+    expect(events).toContainEqual({ type: 'mode-change', mode: 'default' })
+    const approval = firstResults(history)[0]
+    expect(approval.is_error).toBeFalsy()
+    expect(approval.content).toContain('approved')
+    expect(ranTool('run_bash', ran)).toBe(true)
+  })
+
+  it('"always" approves the plan and stops asking about edits', async () => {
+    h.script = [toolThenDone([call('exit_plan_mode', { plan: 'do it' })]), textThenDone('done')]
+    const { events } = await drive({ mode: 'plan', ...asker('always') })
+    expect(events).toContainEqual({ type: 'mode-change', mode: 'acceptEdits' })
+  })
+
+  it('rejecting a plan keeps the session read-only', async () => {
+    const ran: string[] = []
+    h.toolHandlers.run_bash = () => { ran.push('run_bash'); return { content: 'ok' } }
+    h.script = [
+      toolThenDone([call('exit_plan_mode', { plan: 'delete everything' })]),
+      toolThenDone([call('run_bash', { command: 'rm -rf build' })]),
+      textThenDone('done'),
+    ]
+
+    const { events, history } = await drive({ mode: 'plan', ...asker('no') })
+
+    expect(types(events)).not.toContain('mode-change')
+    const rejection = firstResults(history)[0]
+    expect(rejection.is_error).toBe(true)
+    expect(rejection.content).toContain('still in plan mode')
+    expect(ranTool('run_bash', ran)).toBe(false)
+  })
+
+  it('never routes plan approval through the rule store', async () => {
+    // An "always" that persisted as a permission rule would auto-approve every
+    // future plan — plan mode would silently stop being a gate at all.
+    h.script = [toolThenDone([call('exit_plan_mode', { plan: 'do it' })]), textThenDone('done')]
+    const a = asker('always')
+    await drive({ mode: 'plan', ...a })
+    expect(a.calls).toEqual(['exit_plan_mode'])
+    expect(h.checkCalls).toBe(0)
+  })
+
+  it('leaves an ordinary run untouched', async () => {
+    const ran: string[] = []
+    h.toolHandlers.run_bash = () => { ran.push('run_bash'); return { content: 'ok' } }
+    h.script = [toolThenDone([call('run_bash', { command: 'rm -rf build' })]), textThenDone('done')]
+    const { history } = await drive({ ...asker('yes') })
+    expect(firstResults(history)[0].is_error).toBeFalsy()
+    expect(ranTool('run_bash', ran)).toBe(true)
   })
 })

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -1,11 +1,11 @@
 import { existsSync } from 'fs'
 import { chat } from '../llm/client.js'
 import { confinePath } from '../tools/paths.js'
-import { TOOLS, getTool, toOllamaTools } from '../tools/registry.js'
+import { getTool, toOllamaTools, toolsForMode } from '../tools/registry.js'
 import { validateInput, exampleInput } from '../tools/validate.js'
 import { buildSystemPrompt } from '../prompt/system.js'
 import { loadProjectContext } from '../prompt/context.js'
-import { check, type PermissionContext } from '../permissions/policy.js'
+import { check, isReadOnlyCommand, type PermissionContext, type PermissionMode } from '../permissions/policy.js'
 import { loadConfig, EFFORT_OPTIONS, DEFAULT_NUM_CTX_CAP } from '../config.js'
 import { HookBus } from '../hooks/bus.js'
 import {
@@ -51,6 +51,44 @@ function readGuard(name: string, input: unknown, seen: Set<string>): string | nu
   if (name === 'write_file' && !existsSync(abs)) return null
   const verb = name === 'edit_file' ? 'edit' : 'overwrite'
   return `I won't ${verb} ${p} without seeing it first — I don't want to clobber something. Read it with read_file, then retry the ${name}.`
+}
+
+/** The tools plan mode advertises — the set planGuard holds the model to. */
+const PLAN_TOOLS = new Set(toolsForMode('plan').map((t) => t.name))
+
+/**
+ * Harness-enforced plan mode, the mechanical twin of the prompt's "READ-ONLY".
+ *
+ * Withholding the write tools from the schema stops most of this, but a small
+ * model that has seen `edit_file` earlier in the transcript will call it anyway,
+ * and a model asked not to write will still reach for `run_bash` to do it. So
+ * the boundary is enforced here rather than trusted to the prompt: a mutating
+ * call in plan mode never reaches the tool handler, and the model is told what
+ * to do instead of being left to guess from a bare refusal.
+ *
+ * Returns an actionable error string to block the call, or null to allow it.
+ */
+function planGuard(name: string, input: unknown, mode: PermissionMode): string | null {
+  if (mode !== 'plan') return null
+  if (!PLAN_TOOLS.has(name)) {
+    return (
+      `You're in plan mode, which is read-only, so ${name} did not run and nothing changed. ` +
+      `Finish researching with read_file, grep, glob and read-only run_bash commands, then ` +
+      `call exit_plan_mode with your plan. The user approves it before any of it happens.`
+    )
+  }
+  if (name === 'run_bash') {
+    const command = (input as { command?: unknown }).command
+    if (typeof command === 'string' && !isReadOnlyCommand(command)) {
+      return (
+        `You're in plan mode, so only commands that report can run — this one was refused ` +
+        `and nothing happened. Use ls, cat, grep, git status/log/diff and the like (one ` +
+        `command at a time, no pipes or &&). Anything that builds, installs, writes or ` +
+        `deletes belongs in the plan you hand to exit_plan_mode, not in this turn.`
+      )
+    }
+  }
+  return null
 }
 
 /**
@@ -125,6 +163,8 @@ export interface RunAgentOpts {
   /** Base64-encoded images attached to this turn's user message. */
   images?: string[]
   permissions: PermissionContext
+  /** Permission mode at the start of the run; approving a plan changes it. */
+  mode?: PermissionMode
   hooks?: HookBus
   signal?: AbortSignal
   num_ctx?: number
@@ -144,9 +184,13 @@ export interface RunAgentOpts {
 export async function* runAgent(opts: RunAgentOpts): AsyncGenerator<AgentEvent, MiiMessage[]> {
   const { model, cwd, permissions, hooks, signal, num_ctx } = opts
   const startTime = Date.now()
-  const ollamaTools = toOllamaTools(TOOLS)
-  const toolNames = TOOLS.map((t) => t.name)
   const cfg = loadConfig()
+  /**
+   * Live for the whole run: approving a plan flips it mid-run, and everything
+   * derived from it — the advertised tools, the system prompt, what the
+   * permission gate allows — is rebuilt per turn so nothing trails a turn behind.
+   */
+  let mode: PermissionMode = opts.mode ?? 'default'
   // Effort drives temperature + output cap. high → num_predict -1 (unlimited),
   // which ollama.chat omits so the model runs to its own stop.
   const effort = EFFORT_OPTIONS[cfg.effort ?? 'medium']
@@ -156,9 +200,9 @@ export async function* runAgent(opts: RunAgentOpts): AsyncGenerator<AgentEvent, 
   const ctxCap = cfg.numCtxCap && cfg.numCtxCap > 0 ? cfg.numCtxCap : DEFAULT_NUM_CTX_CAP
   const cappedCtx =
     typeof num_ctx === 'number' && num_ctx > 0 ? Math.min(num_ctx, ctxCap) : undefined
-  // Built after cappedCtx: the prompt sizes itself to the window we actually
-  // negotiated, dropping its optional layer when there is no room to spare.
-  const system = buildSystemPrompt(TOOLS, cwd, loadProjectContext(cwd), cappedCtx)
+  // Read once: MIII.md is the same file all run, and re-reading it per turn
+  // would let an edit land mid-task and silently change the rules underfoot.
+  const projectContext = loadProjectContext(cwd)
 
   const history: MiiMessage[] = [
     ...opts.history,
@@ -186,6 +230,16 @@ export async function* runAgent(opts: RunAgentOpts): AsyncGenerator<AgentEvent, 
   let endedCleanly = false
 
   for (let turn = 0; turn < MAX_TURNS; turn++) {
+    // Derived from `mode`, which the user can change mid-run by approving a
+    // plan. The model must see the tools it actually has this turn, and a
+    // near-miss name must only ever resolve to one of them.
+    const activeTools = toolsForMode(mode)
+    const ollamaTools = toOllamaTools(activeTools)
+    const toolNames = activeTools.map((t) => t.name)
+    // Built after cappedCtx: the prompt sizes itself to the window we actually
+    // negotiated, dropping its optional layer when there is no room to spare.
+    const system = buildSystemPrompt(activeTools, cwd, projectContext, cappedCtx, mode)
+
     let text = ''
     let tool_calls: Array<{ function: { name: string; arguments: Record<string, unknown> } }> | undefined
     // Reasoning models think THEN answer. Some providers still trickle a few
@@ -415,7 +469,61 @@ export async function* runAgent(opts: RunAgentOpts): AsyncGenerator<AgentEvent, 
         continue
       }
 
-      const decision = await check(use.name, use.input, permissions)
+      const blocked = planGuard(use.name, use.input, mode)
+      if (blocked) {
+        const r: ToolResultBlock = {
+          type: 'tool_result',
+          tool_use_id: use.id,
+          content: blocked,
+          is_error: true,
+        }
+        results.push(r)
+        yield { type: 'tool-result', block: r }
+        continue
+      }
+
+      // The one call that changes the rules rather than the project. It is put
+      // to the user directly instead of through check(): the answer decides how
+      // the rest of the run behaves, and an "always" here must never be
+      // persisted as a permission rule — a saved "stop asking me to approve
+      // plans" would make plan mode a no-op forever after.
+      if (use.name === 'exit_plan_mode' && mode === 'plan') {
+        const answer = await permissions.ask('exit_plan_mode', use.input)
+        if (answer === 'no') {
+          const r: ToolResultBlock = {
+            type: 'tool_result',
+            tool_use_id: use.id,
+            content:
+              'The user did not approve this plan, so you are still in plan mode and nothing ' +
+              'has changed. Ask what they want different, or go read more, then propose a ' +
+              'revised plan with exit_plan_mode. Do not try to make changes.',
+            is_error: true,
+          }
+          results.push(r)
+          yield { type: 'tool-result', block: r }
+          continue
+        }
+        // "Always" is the second yes: approve the plan AND stop prompting for
+        // the edits carrying it out, which is what a user who just read the
+        // whole plan is actually agreeing to.
+        mode = answer === 'always' ? 'acceptEdits' : 'default'
+        yield { type: 'mode-change', mode }
+        const r: ToolResultBlock = {
+          type: 'tool_result',
+          tool_use_id: use.id,
+          content:
+            'The user approved the plan. You are out of plan mode and the write tools are ' +
+            'available again' +
+            (mode === 'acceptEdits' ? ', and file edits will no longer be prompted' : '') +
+            '. Carry it out now, starting with the first step. Do not restate the plan — the ' +
+            'user has read it. Track progress with write_todos if it runs to several steps.',
+        }
+        results.push(r)
+        yield { type: 'tool-result', block: r }
+        continue
+      }
+
+      const decision = await check(use.name, use.input, { ...permissions, mode })
       if (decision === 'deny') {
         const r: ToolResultBlock = {
           type: 'tool_result',

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -1,3 +1,5 @@
+import type { PermissionMode } from '../permissions/policy.js'
+
 export interface TextBlock {
   type: 'text'
   text: string
@@ -36,6 +38,11 @@ export type AgentEvent =
   | { type: 'tool-use'; block: ToolUse }
   | { type: 'tool-result'; block: ToolResultBlock }
   | { type: 'permission-denied'; toolName: string; tool_use_id: string }
+  /**
+   * The permission mode changed mid-run — the user approved a plan. The UI
+   * mirrors it so the indicator and the next turn agree with the loop.
+   */
+  | { type: 'mode-change'; mode: PermissionMode }
   | { type: 'turn-end'; stop_reason: StopReason }
   | { type: 'done'; prompt_tokens: number; eval_tokens: number }
   | { type: 'aborted'; prompt_tokens: number; eval_tokens: number; duration_ms: number }

--- a/src/commands/custom.test.ts
+++ b/src/commands/custom.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, beforeEach, afterAll } from 'vitest'
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { expandCommand, parseFrontmatter } from './custom.js'
+
+const root = mkdtempSync(join(tmpdir(), 'miii-cmds-'))
+const home = join(root, 'home')
+const project = join(root, 'project')
+for (const d of [home, project]) mkdirSync(d, { recursive: true })
+
+const originalHome = process.env.HOME
+process.env.HOME = home
+// Imported after HOME is redirected: the user-scope directory is resolved from
+// it, and a module loaded first would look in the real home directory.
+const { loadCustomCommands } = await import('./custom.js')
+
+afterAll(() => {
+  if (originalHome === undefined) delete process.env.HOME
+  else process.env.HOME = originalHome
+  rmSync(root, { recursive: true, force: true })
+})
+
+function write(base: string, name: string, body: string) {
+  const dir = join(base, '.miii', 'commands')
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(join(dir, name), body, 'utf-8')
+}
+
+beforeEach(() => {
+  for (const d of [home, project]) rmSync(join(d, '.miii'), { recursive: true, force: true })
+})
+
+describe('loadCustomCommands', () => {
+  it('turns a Markdown file into a command named after it', () => {
+    write(project, 'review.md', 'Review the staged diff.')
+    const [cmd] = loadCustomCommands(project)
+    expect(cmd.name).toBe('/review')
+    expect(cmd.body).toBe('Review the staged diff.')
+    expect(cmd.scope).toBe('project')
+  })
+
+  it('reads the description out of frontmatter, and summarises without it', () => {
+    write(project, 'a.md', '---\ndescription: check the tests\n---\nRun the suite.')
+    write(project, 'b.md', '# Ship it\n\nDo the release.')
+    const byName = Object.fromEntries(loadCustomCommands(project).map((c) => [c.name, c]))
+    expect(byName['/a'].description).toBe('check the tests')
+    expect(byName['/a'].body).toBe('Run the suite.')
+    // No frontmatter: the first line stands in, with its heading marker gone.
+    expect(byName['/b'].description).toBe('Ship it')
+  })
+
+  it('lets a project command shadow a user command of the same name', () => {
+    write(home, 'review.md', 'user version')
+    write(project, 'review.md', 'project version')
+    const found = loadCustomCommands(project).filter((c) => c.name === '/review')
+    expect(found).toHaveLength(1)
+    expect(found[0].body).toBe('project version')
+    expect(found[0].scope).toBe('project')
+  })
+
+  it('finds user commands when the project has none', () => {
+    write(home, 'standup.md', 'Summarise yesterday.')
+    const [cmd] = loadCustomCommands(project)
+    expect(cmd.name).toBe('/standup')
+    expect(cmd.scope).toBe('user')
+  })
+
+  it('skips files that cannot be a command', () => {
+    write(project, 'notes.txt', 'not markdown')
+    write(project, 'bad name.md', 'has a space')
+    write(project, 'empty.md', '   \n  ')
+    write(project, 'ok.md', 'fine')
+    expect(loadCustomCommands(project).map((c) => c.name)).toEqual(['/ok'])
+  })
+
+  it('returns nothing when there is no commands directory', () => {
+    expect(loadCustomCommands(project)).toEqual([])
+  })
+})
+
+describe('parseFrontmatter', () => {
+  it('leaves a body with no frontmatter alone', () => {
+    expect(parseFrontmatter('just a prompt')).toEqual({ body: 'just a prompt' })
+  })
+
+  it('treats an unterminated block as body, not frontmatter', () => {
+    const { body, description } = parseFrontmatter('---\ndescription: x\nstill going')
+    expect(description).toBeUndefined()
+    expect(body).toContain('still going')
+  })
+
+  it('strips quotes from the description', () => {
+    expect(parseFrontmatter('---\ndescription: "quoted"\n---\nbody').description).toBe('quoted')
+  })
+})
+
+describe('expandCommand', () => {
+  it('substitutes $ARGUMENTS', () => {
+    expect(expandCommand('Review $ARGUMENTS please', 'src/a.ts')).toBe('Review src/a.ts please')
+  })
+
+  it('substitutes positional words', () => {
+    expect(expandCommand('move $1 to $2', ' a.ts b.ts ')).toBe('move a.ts to b.ts')
+  })
+
+  it('empties an unfilled positional rather than leaving it as text', () => {
+    // A literal "$2" left in the prompt is something the model tries to
+    // interpret; an absent argument should simply be absent.
+    expect(expandCommand('check $1 and $2', 'a.ts')).toBe('check a.ts and')
+  })
+
+  it('appends arguments a body never references, instead of dropping them', () => {
+    expect(expandCommand('Review the diff.', 'focus on auth')).toBe('Review the diff.\n\nfocus on auth')
+  })
+
+  it('leaves a body alone when nothing was typed after the command', () => {
+    expect(expandCommand('Review the diff.', '')).toBe('Review the diff.')
+    expect(expandCommand('Review $ARGUMENTS.', '')).toBe('Review .')
+  })
+})

--- a/src/commands/custom.ts
+++ b/src/commands/custom.ts
@@ -1,0 +1,167 @@
+/**
+ * User-defined slash commands.
+ *
+ * A Markdown file is a command: `.miii/commands/review.md` becomes `/review`,
+ * and running it sends the file's body as the prompt. That is the whole idea —
+ * the prompts you retype every week become part of the project instead of
+ * living in your shell history.
+ *
+ *   <cwd>/.miii/commands/*.md   project scope — checked in, shared with the team
+ *   ~/.miii/commands/*.md       user scope — yours, in every project
+ *
+ * A project command shadows a user command of the same name, so a repo can
+ * override a personal default rather than collide with it.
+ *
+ * Optional YAML-ish frontmatter sets the palette description; everything after
+ * it is the prompt:
+ *
+ *   ---
+ *   description: review the staged diff
+ *   ---
+ *   Review the staged diff for bugs. Focus on $ARGUMENTS.
+ *
+ * Arguments: `$ARGUMENTS` is everything typed after the command name, and
+ * `$1`…`$9` are its whitespace-separated words. A command with no placeholder
+ * gets the arguments appended, so `/review src/a.ts` is never silently dropped.
+ */
+import { existsSync, readdirSync, readFileSync } from 'fs'
+import { join, basename } from 'path'
+import { homedir } from 'os'
+
+export type CommandScope = 'project' | 'user'
+
+export interface CustomCommand {
+  /** Slash-prefixed, e.g. "/review". */
+  name: string
+  description: string
+  /** The prompt body, before argument substitution. */
+  body: string
+  scope: CommandScope
+  source: string
+}
+
+/** Only sane command names — the palette matches on these by prefix. */
+const NAME_RE = /^[a-z0-9][a-z0-9_-]*$/i
+
+/** A command file bigger than this is a mistake, not a prompt. */
+const MAX_BYTES = 64 * 1024
+
+function commandsDir(scope: CommandScope, cwd: string): string {
+  return scope === 'user'
+    ? join(homedir(), '.miii', 'commands')
+    : join(cwd, '.miii', 'commands')
+}
+
+/**
+ * Split leading `---` frontmatter off the body. Deliberately not a YAML parser:
+ * the only key that means anything is `description`, and a command file that
+ * fails to parse should still run rather than vanish from the palette.
+ */
+export function parseFrontmatter(text: string): { description?: string; body: string } {
+  const normalized = text.replace(/^﻿/, '').replace(/\r\n/g, '\n')
+  if (!normalized.startsWith('---\n')) return { body: normalized.trim() }
+  const end = normalized.indexOf('\n---', 3)
+  if (end === -1) return { body: normalized.trim() }
+  const head = normalized.slice(4, end)
+  const body = normalized.slice(normalized.indexOf('\n', end + 1) + 1)
+  let description: string | undefined
+  for (const line of head.split('\n')) {
+    const m = /^\s*description\s*:\s*(.*)$/i.exec(line)
+    if (!m) continue
+    description = m[1].trim().replace(/^['"]|['"]$/g, '')
+  }
+  return { ...(description ? { description } : {}), body: body.trim() }
+}
+
+/** First non-empty line of the body, clipped — the fallback palette description. */
+function summarize(body: string): string {
+  const line = body.split('\n').find((l) => l.trim()) ?? ''
+  const clean = line.replace(/^#+\s*/, '').trim()
+  return clean.length > 60 ? clean.slice(0, 59) + '…' : clean || 'custom command'
+}
+
+function loadScope(scope: CommandScope, cwd: string): CustomCommand[] {
+  const dir = commandsDir(scope, cwd)
+  if (!existsSync(dir)) return []
+  let files: string[]
+  try {
+    files = readdirSync(dir).filter((f) => f.toLowerCase().endsWith('.md'))
+  } catch {
+    return []
+  }
+  const out: CustomCommand[] = []
+  for (const file of files.sort()) {
+    const stem = basename(file, file.slice(file.lastIndexOf('.')))
+    if (!NAME_RE.test(stem)) continue
+    const source = join(dir, file)
+    let raw: string
+    try {
+      raw = readFileSync(source, 'utf-8')
+    } catch {
+      continue
+    }
+    if (raw.length > MAX_BYTES) continue
+    const { description, body } = parseFrontmatter(raw)
+    if (!body) continue
+    out.push({
+      name: `/${stem.toLowerCase()}`,
+      description: description || summarize(body),
+      body,
+      scope,
+      source,
+    })
+  }
+  return out
+}
+
+/**
+ * Every custom command in force, project first. Callers rely on that order for
+ * shadowing, so it is part of the contract rather than an accident of reading.
+ */
+export function loadCustomCommands(cwd: string = process.cwd()): CustomCommand[] {
+  const project = loadScope('project', cwd)
+  const taken = new Set(project.map((c) => c.name))
+  const user = loadScope('user', cwd).filter((c) => !taken.has(c.name))
+  return [...project, ...user]
+}
+
+/**
+ * Cached view of loadCustomCommands, because the palette re-filters on every
+ * keystroke and each call is a directory read. Dropped whenever a command could
+ * have changed underneath us — see invalidateCustomCommands.
+ */
+let cache: CustomCommand[] | null = null
+
+export function customCommands(cwd: string = process.cwd()): CustomCommand[] {
+  if (!cache) cache = loadCustomCommands(cwd)
+  return cache
+}
+
+/** Forget the cache — called when the palette opens, so an edit shows up. */
+export function invalidateCustomCommands(): void {
+  cache = null
+}
+
+export function findCustomCommand(name: string, cwd?: string): CustomCommand | undefined {
+  return customCommands(cwd).find((c) => c.name === name.toLowerCase())
+}
+
+/**
+ * Substitute the typed arguments into a command body.
+ *
+ * `$ARGUMENTS` takes the whole argument string and `$1`…`$9` take individual
+ * words; an unfilled positional becomes empty rather than staying as literal
+ * `$3`, which the model would otherwise treat as text to reason about. When the
+ * body references no placeholder at all, the arguments are appended — typing
+ * them and having them silently disappear is the worse failure.
+ */
+export function expandCommand(body: string, args: string): string {
+  const argv = args.trim() ? args.trim().split(/\s+/) : []
+  const hasPlaceholder = /\$ARGUMENTS\b|\$[1-9]\b/.test(body)
+  const filled = body
+    .replace(/\$ARGUMENTS\b/g, args.trim())
+    .replace(/\$([1-9])\b/g, (_, d: string) => argv[Number(d) - 1] ?? '')
+    .replace(/[ \t]+$/gm, '')
+  if (hasPlaceholder || !args.trim()) return filled.trim()
+  return `${filled.trim()}\n\n${args.trim()}`
+}

--- a/src/permissions/policy.test.ts
+++ b/src/permissions/policy.test.ts
@@ -7,6 +7,14 @@ import {
   widestPattern,
   hasUnquotedShellOperator,
   ruleAllows,
+  isReadOnlyCommand,
+  nextMode,
+  check,
+  PERMISSION_MODES,
+  MODE_LABEL,
+  MODE_HINT,
+  type PermissionMode,
+  type AskFn,
 } from './policy.js'
 
 /** Approve `command` with "always", then ask whether `next` runs unprompted. */
@@ -241,5 +249,100 @@ describe('a wildcard rule never spans a command boundary', () => {
   it('leaves path subjects alone — an & in a filename is not an operator', () => {
     const rule = { tool: 'write_file', pattern: 'src/*' }
     expect(ruleAllows(rule, 'write_file', 'src/a&b.ts')).toBe(true)
+  })
+})
+
+describe('permission modes', () => {
+  it('cycles through every mode and returns to the start', () => {
+    const seen: PermissionMode[] = []
+    let m: PermissionMode = 'default'
+    for (let i = 0; i < PERMISSION_MODES.length; i++) {
+      seen.push(m)
+      m = nextMode(m)
+    }
+    expect(seen).toEqual(PERMISSION_MODES)
+    expect(m).toBe('default')
+  })
+
+  it('labels and explains every mode', () => {
+    for (const mode of PERMISSION_MODES) {
+      expect(MODE_LABEL[mode], mode).toBeTruthy()
+      expect(MODE_HINT[mode], mode).toBeTruthy()
+    }
+  })
+})
+
+describe('isReadOnlyCommand', () => {
+  it('accepts commands that only report', () => {
+    for (const cmd of ['ls', 'ls -la src', 'cat package.json', 'grep -rn foo src', 'wc -l a.ts']) {
+      expect(isReadOnlyCommand(cmd), cmd).toBe(true)
+    }
+  })
+
+  it("does not mistake grep's -i for sed's", () => {
+    // Case-insensitive search is most of what planning uses grep for; treating
+    // -i as "in place" here would block the tool's commonest flag.
+    expect(isReadOnlyCommand('grep -i todo src')).toBe(true)
+    expect(isReadOnlyCommand('grep -rin todo src')).toBe(true)
+  })
+
+  it('lets find report but not act', () => {
+    expect(isReadOnlyCommand('find . -name "*.ts"')).toBe(true)
+    expect(isReadOnlyCommand('find . -name "*.ts" -delete')).toBe(false)
+    expect(isReadOnlyCommand('find . -exec rm {} ;')).toBe(false)
+  })
+
+  it('accepts git subcommands that only report, and no others', () => {
+    for (const cmd of ['git status', 'git log --oneline -5', 'git diff HEAD']) {
+      expect(isReadOnlyCommand(cmd), cmd).toBe(true)
+    }
+    for (const cmd of ['git commit -m x', 'git push', 'git reset --hard', 'git']) {
+      expect(isReadOnlyCommand(cmd), cmd).toBe(false)
+    }
+  })
+
+  it('rejects anything that writes', () => {
+    for (const cmd of ['rm -rf build', 'npm install', 'mkdir x', 'touch a', 'sed -i s/a/b/ f']) {
+      expect(isReadOnlyCommand(cmd), cmd).toBe(false)
+    }
+  })
+
+  it('refuses a compound command however harmless its first token', () => {
+    // The exact hole the wildcard rule scoping exists to close, in the other
+    // direction: "ls" says nothing about what follows the &&.
+    for (const cmd of ['ls && rm -rf build', 'cat a > b', 'ls; rm x', 'echo $(rm -rf /)', 'ls | tee out']) {
+      expect(isReadOnlyCommand(cmd), cmd).toBe(false)
+    }
+  })
+
+  it('rejects an empty command', () => {
+    expect(isReadOnlyCommand('   ')).toBe(false)
+  })
+})
+
+describe('check() honours the mode', () => {
+  const never: AskFn = async () => {
+    throw new Error('should not have prompted')
+  }
+
+  it('never asks in bypass mode', async () => {
+    expect(await check('run_bash', { command: 'rm -rf /' }, { ask: never, mode: 'bypass' })).toBe('allow')
+  })
+
+  it('stops asking about edits in acceptEdits, but not about commands', async () => {
+    expect(await check('edit_file', { path: 'a.ts' }, { ask: never, mode: 'acceptEdits' })).toBe('allow')
+    let asked = false
+    const decision = await check(
+      'run_bash',
+      { command: 'zzz-not-a-real-program --xyz' },
+      { ask: async () => { asked = true; return 'no' }, mode: 'acceptEdits' },
+    )
+    expect(asked).toBe(true)
+    expect(decision).toBe('deny')
+  })
+
+  it('always allows the read-only tools', async () => {
+    expect(await check('read_file', { path: 'a.ts' }, { ask: never })).toBe('allow')
+    expect(await check('grep', { pattern: 'x' }, { ask: never, mode: 'plan' })).toBe('allow')
   })
 })

--- a/src/permissions/policy.ts
+++ b/src/permissions/policy.ts
@@ -1,8 +1,16 @@
 /**
- * Permission policy with a persistent rule store.
+ * Permission policy: a persistent rule store plus the mode that decides how
+ * much gets asked at all.
  *
- * Rules live in ~/.miii/permissions.json as { tool, pattern } pairs. `pattern`
- * is a glob matched against a per-tool "subject" string:
+ * Rules live in two files, both `{ rules: [{ tool, pattern }] }`:
+ *   <cwd>/.miii/permissions.json   project scope — where "always" writes
+ *   ~/.miii/permissions.json       user scope — applies in every project
+ * Both are read on every call; the project file is written by default because a
+ * rule's subject is usually project-relative. A path pattern like "src/index.ts"
+ * saved globally would auto-allow that path in *every* repo you ever open, which
+ * is not what anyone means by "don't ask again".
+ *
+ * `pattern` is a glob matched against a per-tool "subject" string:
  *   run_bash                 → the command
  *   read/write/edit_file     → the path
  *   grep/glob                → the search root path
@@ -16,6 +24,11 @@
  *
  * A wildcard rule never authorizes a compound command ("npm test && rm -rf ~"):
  * see ruleAllows(). That holds for hand-edited globs too.
+ *
+ * On top of the rules sits the permission MODE (shift+tab in the UI), which can
+ * widen or narrow the whole gate: `plan` makes the session read-only, `default`
+ * consults the rules, `acceptEdits` stops asking about file writes, and `bypass`
+ * stops asking about anything.
  */
 import { readFileSync, writeFileSync, mkdirSync, existsSync, renameSync } from 'fs'
 import { join } from 'path'
@@ -33,44 +46,124 @@ export type AskFn = (toolName: string, input: unknown) => Promise<AskAnswer>
 
 export interface PermissionContext {
   ask: AskFn
+  /**
+   * The mode in force for this call. Passed per-call rather than stored,
+   * because approving a plan changes it mid-run: the loop rebuilds the context
+   * each time so a call is never judged against a stale mode.
+   */
+  mode?: PermissionMode
 }
 
-const RULES_DIR = join(homedir(), '.miii')
-const RULES_PATH = join(RULES_DIR, 'permissions.json')
+/**
+ * How much the harness asks before acting.
+ *
+ * - `default`    — stored rules auto-allow; anything else prompts.
+ * - `plan`       — read-only. Nothing may be written or run outside the
+ *                  read-only command set; the agent researches and proposes a
+ *                  plan via exit_plan_mode, which the user approves to leave.
+ * - `acceptEdits`— file writes inside the workspace stop prompting; commands
+ *                  still do, because a command can reach outside it.
+ * - `bypass`     — nothing prompts. For a sandbox or a throwaway tree.
+ */
+export type PermissionMode = 'default' | 'plan' | 'acceptEdits' | 'bypass'
 
-export function loadRules(): Rule[] {
-  if (!existsSync(RULES_PATH)) return []
+/** Cycle order for shift+tab. `default` is first so the cycle returns to it. */
+export const PERMISSION_MODES: PermissionMode[] = ['default', 'plan', 'acceptEdits', 'bypass']
+
+export const MODE_LABEL: Record<PermissionMode, string> = {
+  default: 'normal',
+  plan: 'plan mode',
+  acceptEdits: 'auto-accept edits',
+  bypass: 'bypass permissions',
+}
+
+/** One-line explanation shown when the mode changes. */
+export const MODE_HINT: Record<PermissionMode, string> = {
+  default: 'asks before writing files or running commands',
+  plan: 'read-only — researches and proposes a plan for you to approve',
+  acceptEdits: 'writes files without asking · commands still prompt',
+  bypass: 'runs everything without asking — be sure about this tree',
+}
+
+export function nextMode(mode: PermissionMode): PermissionMode {
+  const i = PERMISSION_MODES.indexOf(mode)
+  return PERMISSION_MODES[(i + 1) % PERMISSION_MODES.length]
+}
+
+/** Where an "always" answer is persisted. */
+export type RuleScope = 'project' | 'user'
+
+const USER_RULES_DIR = join(homedir(), '.miii')
+
+/**
+ * Resolved lazily rather than at module load: the project scope follows the
+ * working directory, and reading it once at import would pin it to whatever
+ * directory the process happened to start in.
+ */
+function rulesDir(scope: RuleScope): string {
+  return scope === 'user' ? USER_RULES_DIR : join(process.cwd(), '.miii')
+}
+
+function rulesPath(scope: RuleScope): string {
+  return join(rulesDir(scope), 'permissions.json')
+}
+
+function readRulesFile(path: string): Rule[] {
+  if (!existsSync(path)) return []
   try {
-    const data = JSON.parse(readFileSync(RULES_PATH, 'utf-8')) as { rules?: Rule[] }
-    return Array.isArray(data.rules) ? data.rules : []
+    const data = JSON.parse(readFileSync(path, 'utf-8')) as { rules?: Rule[] }
+    return Array.isArray(data.rules) ? data.rules.filter((r) => r && r.tool && r.pattern) : []
   } catch {
     return []
   }
 }
 
-function saveRules(rules: Rule[]): void {
-  mkdirSync(RULES_DIR, { recursive: true })
+/** Rules stored in one scope. */
+export function loadScopedRules(scope: RuleScope): Rule[] {
+  return readRulesFile(rulesPath(scope))
+}
+
+/**
+ * Every rule in force here: the project's own, then the user-wide ones. Order
+ * is presentation-only — a call is allowed if any rule matches.
+ */
+export function loadRules(): Rule[] {
+  return [...loadScopedRules('project'), ...loadScopedRules('user')]
+}
+
+function saveRules(scope: RuleScope, rules: Rule[]): void {
+  const dir = rulesDir(scope)
+  mkdirSync(dir, { recursive: true })
   // Write to a temp file then rename — atomic swap so a crash mid-write can't
   // corrupt the rule file.
-  const tmp = RULES_PATH + '.tmp'
+  const path = rulesPath(scope)
+  const tmp = path + '.tmp'
   writeFileSync(tmp, JSON.stringify({ rules }, null, 2), 'utf-8')
-  renameSync(tmp, RULES_PATH)
+  renameSync(tmp, path)
 }
 
-export function addRule(tool: string, pattern: string): void {
-  addRules(tool, [pattern])
+export function addRule(tool: string, pattern: string, scope: RuleScope = 'project'): void {
+  addRules(tool, [pattern], scope)
 }
 
-/** Persist several patterns for one tool in a single load/save cycle. */
-export function addRules(tool: string, patterns: string[]): void {
-  const rules = loadRules()
+/**
+ * Persist several patterns for one tool in a single load/save cycle.
+ *
+ * Deduplication is against the target scope only. A pattern already granted
+ * user-wide is not re-written into the project file, so the check below also
+ * consults the merged view.
+ */
+export function addRules(tool: string, patterns: string[], scope: RuleScope = 'project'): void {
+  const existing = loadRules()
+  const rules = loadScopedRules(scope)
   let changed = false
   for (const pattern of patterns) {
+    if (existing.some((r) => r.tool === tool && r.pattern === pattern)) continue
     if (rules.some((r) => r.tool === tool && r.pattern === pattern)) continue
     rules.push({ tool, pattern })
     changed = true
   }
-  if (changed) saveRules(rules)
+  if (changed) saveRules(scope, rules)
 }
 
 /** Extract the string a rule pattern matches against for a given tool call. */
@@ -269,12 +362,93 @@ export function ruleAllows(rule: Rule, toolName: string, subject: string): boole
 /** Read-only tools are always allowed — never prompt for these. */
 const ALWAYS_ALLOW = new Set(['read_file', 'grep', 'glob'])
 
+/** Tools that write to the workspace — what `acceptEdits` stops asking about. */
+export const EDIT_TOOLS = new Set(['write_file', 'edit_file'])
+
+/**
+ * Programs that only report. The list is deliberately short and boring: it is
+ * the set of things plan mode will even offer to run, so anything whose
+ * read-only-ness depends on an argument (`sed -i`, `find -delete`) stays off it.
+ */
+const READ_ONLY_PROGRAMS = new Set([
+  'ls', 'cat', 'head', 'tail', 'wc', 'file', 'stat', 'du', 'df',
+  'pwd', 'which', 'whoami', 'date', 'env', 'printenv', 'echo',
+  'grep', 'egrep', 'fgrep', 'rg', 'ag', 'tree', 'diff', 'cmp',
+  'find', 'sort', 'uniq', 'cut', 'tr', 'nl',
+  'node', 'python', 'python3', 'jq', 'basename', 'dirname', 'realpath',
+])
+
+/**
+ * git subcommands that only report. `log`/`diff`/`show` are the ones that make
+ * planning useful — what changed recently is most of the answer to "why is this
+ * like this".
+ */
+const READ_ONLY_GIT = new Set([
+  'status', 'log', 'diff', 'show', 'branch', 'remote', 'ls-files',
+  'blame', 'describe', 'rev-parse', 'tag', 'shortlog',
+])
+
+/**
+ * Flags that turn a listed program into a writing one. `find` is the reason
+ * this exists: it only reports until you hand it -delete or -exec.
+ *
+ * Deliberately no bare `-i`. It means "in place" to sed and perl, which are not
+ * on the list above and never will be — but it means "ignore case" to grep,
+ * which is on it, and blocking `grep -i` would make plan mode useless for the
+ * searching it is mostly for.
+ */
+const WRITING_FLAGS = [
+  /(?:^|\s)--in-place\b/,
+  /(?:^|\s)--write\b/,
+  /(?:^|\s)-delete\b/,
+  /(?:^|\s)-exec\b/,
+  /(?:^|\s)-execdir\b/,
+  /(?:^|\s)-fprint\b/,
+]
+
+/**
+ * Is this shell command safe to run while planning — does it only report?
+ *
+ * A compound command is never read-only however innocent its first token, since
+ * `ls && rm -rf x` starts with `ls`. That is the same command-boundary rule that
+ * stops a wildcard permission rule spanning a `&&` (see ruleAllows), and it
+ * rules out redirections too, which write by definition.
+ *
+ * `node` and `python` are listed because a plan often needs a version or a `-e`
+ * one-liner, and they can obviously write if told to. Which is why plan mode
+ * still sends them through the normal prompt rather than auto-allowing them:
+ * read-only here means "may be offered", never "is safe".
+ */
+export function isReadOnlyCommand(command: string): boolean {
+  const trimmed = command.trim()
+  if (!trimmed) return false
+  if (hasUnquotedShellOperator(trimmed)) return false
+  if (WRITING_FLAGS.some((re) => re.test(trimmed))) return false
+  const tokens = trimmed.split(/\s+/)
+  const prog = tokens[0]
+  if (prog === 'git') return tokens.length > 1 && READ_ONLY_GIT.has(tokens[1])
+  return READ_ONLY_PROGRAMS.has(prog)
+}
+
+/**
+ * The gate every tool call passes through.
+ *
+ * Plan mode is NOT enforced here — the agent loop blocks mutating tools before
+ * this point, with a message steering the model back to proposing a plan. By
+ * the time a call reaches `check` in plan mode it is already something plan
+ * mode permits, and it still has to be approved like anything else.
+ */
 export async function check(
   toolName: string,
   input: unknown,
   ctx: PermissionContext,
 ): Promise<Decision> {
+  const mode = ctx.mode ?? 'default'
+  if (mode === 'bypass') return 'allow'
   if (ALWAYS_ALLOW.has(toolName)) return 'allow'
+  // Edits are already confined to the workspace by the file tools, so
+  // auto-accepting them is bounded in a way auto-accepting a command is not.
+  if (mode === 'acceptEdits' && EDIT_TOOLS.has(toolName)) return 'allow'
 
   const subject = subjectFor(toolName, input)
   const rules = loadRules()

--- a/src/permissions/scope.test.ts
+++ b/src/permissions/scope.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Rule scoping, against a real filesystem.
+ *
+ * These tests exist because the thing being verified is *where* a rule lands,
+ * and a mocked fs would only prove the mock. HOME and cwd are redirected into a
+ * temp tree before policy.js is imported — the user-scope path is resolved at
+ * module load, so the override has to happen first.
+ */
+import { describe, it, expect, beforeEach, afterAll } from 'vitest'
+import { mkdtempSync, mkdirSync, rmSync, existsSync, readFileSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+const root = mkdtempSync(join(tmpdir(), 'miii-scope-'))
+const home = join(root, 'home')
+const project = join(root, 'project')
+const other = join(root, 'other')
+for (const d of [home, project, other]) mkdirSync(d, { recursive: true })
+
+const originalHome = process.env.HOME
+const originalCwd = process.cwd()
+process.env.HOME = home
+process.chdir(project)
+
+const { loadRules, loadScopedRules, addRules, check } = await import('./policy.js')
+
+afterAll(() => {
+  process.chdir(originalCwd)
+  if (originalHome === undefined) delete process.env.HOME
+  else process.env.HOME = originalHome
+  rmSync(root, { recursive: true, force: true })
+})
+
+function reset() {
+  for (const d of [home, project, other]) {
+    rmSync(join(d, '.miii'), { recursive: true, force: true })
+  }
+  process.chdir(project)
+}
+
+/** Write a rules file directly, the way a user hand-editing one would. */
+function seed(dir: string, rules: Array<{ tool: string; pattern: string }>) {
+  mkdirSync(join(dir, '.miii'), { recursive: true })
+  writeFileSync(join(dir, '.miii', 'permissions.json'), JSON.stringify({ rules }), 'utf-8')
+}
+
+beforeEach(reset)
+
+describe('rule scopes', () => {
+  it('writes "always" into the project, not the home directory', () => {
+    addRules('run_bash', ['npm test'])
+    expect(existsSync(join(project, '.miii', 'permissions.json'))).toBe(true)
+    expect(existsSync(join(home, '.miii', 'permissions.json'))).toBe(false)
+  })
+
+  it('does not carry a project rule into another project', () => {
+    // The reason project scope is the default: a path subject is relative, so a
+    // globally stored "src/index.ts" would pre-approve that path in every repo.
+    addRules('write_file', ['src/index.ts'])
+    expect(loadRules()).toHaveLength(1)
+    process.chdir(other)
+    expect(loadRules()).toHaveLength(0)
+  })
+
+  it('applies a user-scope rule in every project', () => {
+    addRules('run_bash', ['git status'], 'user')
+    expect(loadScopedRules('user')).toHaveLength(1)
+    expect(loadScopedRules('project')).toHaveLength(0)
+    process.chdir(other)
+    expect(loadRules().map((r) => r.pattern)).toEqual(['git status'])
+  })
+
+  it('merges both scopes, project first', () => {
+    seed(home, [{ tool: 'run_bash', pattern: 'git status' }])
+    seed(project, [{ tool: 'run_bash', pattern: 'npm test' }])
+    expect(loadRules().map((r) => r.pattern)).toEqual(['npm test', 'git status'])
+  })
+
+  it('does not duplicate a pattern already granted user-wide', () => {
+    addRules('run_bash', ['npm test'], 'user')
+    addRules('run_bash', ['npm test'])
+    expect(loadScopedRules('project')).toHaveLength(0)
+  })
+
+  it('survives a corrupt or partial rules file rather than throwing', () => {
+    mkdirSync(join(project, '.miii'), { recursive: true })
+    writeFileSync(join(project, '.miii', 'permissions.json'), '{not json', 'utf-8')
+    expect(loadRules()).toEqual([])
+    // And a well-formed file with junk entries keeps only the usable ones.
+    seed(project, [{ tool: 'run_bash', pattern: 'ls' }, { tool: '', pattern: '' }])
+    expect(loadRules()).toHaveLength(1)
+  })
+
+  it('auto-allows a call a stored rule covers, without prompting', async () => {
+    seed(project, [{ tool: 'run_bash', pattern: 'npm test *' }])
+    const never = async () => { throw new Error('should not have prompted') }
+    expect(await check('run_bash', { command: 'npm test src/a' }, { ask: never })).toBe('allow')
+  })
+
+  it('persists both the exact command and its glob on "always"', async () => {
+    const decision = await check('run_bash', { command: 'npm run build' }, { ask: async () => 'always' })
+    expect(decision).toBe('allow')
+    const saved = JSON.parse(readFileSync(join(project, '.miii', 'permissions.json'), 'utf-8'))
+    expect(saved.rules.map((r: { pattern: string }) => r.pattern)).toEqual(['npm run build', 'npm run *'])
+  })
+})

--- a/src/prompt/system.test.ts
+++ b/src/prompt/system.test.ts
@@ -5,7 +5,7 @@ import {
   CORE_TOKEN_BUDGET,
   EXTENDED_MIN_CTX,
 } from './system.js'
-import { TOOLS, toOllamaTools } from '../tools/registry.js'
+import { TOOLS, toOllamaTools, toolsForMode } from '../tools/registry.js'
 import type { ProjectContext } from './context.js'
 
 const CWD = '/home/dev/project'
@@ -127,5 +127,38 @@ describe('resolved contradictions', () => {
 
   it('does not tax every finished turn with a what-next question', () => {
     expect(large()).not.toContain('always close by asking')
+  })
+})
+
+describe('plan mode', () => {
+  const plan = (ctx = 4096) => buildSystemPrompt(toolsForMode('plan'), CWD, undefined, ctx, 'plan')
+
+  it('is sent even on a cramped window', () => {
+    // Plan mode changes what the model is *able* to do. A model that is not
+    // told spends its turns calling write tools it does not have.
+    expect(plan(4096)).toContain('Plan mode')
+    expect(plan(4096)).toContain('exit_plan_mode')
+  })
+
+  it('still fits the core budget with the plan tier on top', () => {
+    expect(estimateTokens(plan(4096))).toBeLessThanOrEqual(CORE_TOKEN_BUDGET)
+  })
+
+  it('names only the tools plan mode actually has', () => {
+    const prompt = plan(32768)
+    for (const t of toolsForMode('plan')) expect(prompt).toContain(t.name)
+    // The withheld ones are named in the prose that explains their absence, so
+    // check the tool list line itself rather than the whole prompt.
+    const toolLine = prompt.split('\n').find((l) => l.includes('read_file, ')) ?? ''
+    expect(toolLine).not.toContain('write_file')
+    expect(toolLine).not.toContain('edit_file')
+  })
+
+  it('says nothing about planning in an ordinary session', () => {
+    // exit_plan_mode is not offered outside plan mode; describing it anyway
+    // invites the model to stall instead of doing the work.
+    const normal = buildSystemPrompt(toolsForMode('default'), CWD, undefined, 32768)
+    expect(normal).not.toContain('Plan mode')
+    expect(normal).not.toContain('exit_plan_mode')
   })
 })

--- a/src/prompt/system.ts
+++ b/src/prompt/system.ts
@@ -1,4 +1,5 @@
 import type { Tool } from '../tools/types.js'
+import type { PermissionMode } from '../permissions/policy.js'
 import type { ProjectContext } from './context.js'
 import { CONTEXT_FILENAME, MAX_CONTEXT_BYTES } from './context.js'
 
@@ -116,20 +117,50 @@ File tools are confined to the working directory. Any call may prompt the user f
 }
 
 /**
+ * Plan mode. Sent on every window size, tight ones included: it changes what
+ * the model is *able* to do, so a model that doesn't get told is a model that
+ * spends its turns calling write tools it does not have and reading back
+ * refusals. That earns its tokens even at 4k.
+ */
+function planning(): string {
+  return `
+# Plan mode — READ-ONLY
+You are researching, not building. Nothing you do this turn may change the
+project: you have no write_file and no edit_file, and run_bash will only run
+commands that report (ls, cat, grep, git status/log/diff, …). A command that
+writes is refused, not queued.
+- Work out what the change actually requires: read the real files, follow the
+  call sites, check how the project already does this. Do not guess and do not
+  design against a file you have not opened.
+- Then call exit_plan_mode with the plan. Steps in the order you would do them,
+  each naming the files it touches, concrete enough that the next step is never
+  "figure out how X works". Keep it short — it is a plan, not an essay.
+- The user approves the plan before anything is written. If they reject it, they
+  will say what is wrong: revise and propose again.
+- If the request needs no plan — a question, a lookup, one obvious edit — say so
+  in prose and stop. Do not manufacture a plan for it.
+`
+}
+
+/**
  * Build the system prompt for a turn.
  *
  * `num_ctx` is the window the loop actually negotiated. Pass it so the prompt
  * can size itself; when it is unknown (the provider did not report a window) we
  * send the full prompt, since an unreported window is more often a capable
  * remote model than a cramped local one.
+ *
+ * `mode` is the permission mode in force. Only plan mode changes the prompt —
+ * the others change what gets asked, not what the model should be doing.
  */
 export function buildSystemPrompt(
   tools: Tool[],
   cwd: string,
   project?: ProjectContext,
   num_ctx?: number,
+  mode: PermissionMode = 'default',
 ): string {
-  const base = core(tools, cwd, project)
+  const base = core(tools, cwd, project) + (mode === 'plan' ? planning() : '')
   const roomy = num_ctx === undefined || num_ctx >= EXTENDED_MIN_CTX
   return roomy ? base + extended() : base
 }

--- a/src/tools/exit_plan_mode.ts
+++ b/src/tools/exit_plan_mode.ts
@@ -1,0 +1,41 @@
+import type { Tool } from './types.js'
+
+interface Input {
+  plan: string
+}
+
+/**
+ * The way out of plan mode.
+ *
+ * Plan mode is read-only, so the agent cannot finish a task from inside it — it
+ * researches, then calls this with what it intends to do. The agent loop
+ * intercepts the call, shows the plan to the user for approval, and only leaves
+ * plan mode if they accept. The handler below therefore normally never runs:
+ * it is the answer for a model that calls the tool when it isn't planning,
+ * which happens with small models that have seen the name in the transcript.
+ */
+export const exit_plan_mode: Tool<Input> = {
+  name: 'exit_plan_mode',
+  description:
+    'Present your finished implementation plan and ask the user to approve starting work. ' +
+    'Only for plan mode, and only once research is done — the plan is what you intend to ' +
+    'change, in order. Do not call it to report work you have already finished.',
+  input_schema: {
+    type: 'object',
+    properties: {
+      plan: {
+        type: 'string',
+        description:
+          'The plan, as terminal Markdown. Concise: the steps you will take, in order, ' +
+          'naming the files each one touches.',
+      },
+    },
+    required: ['plan'],
+  },
+  handler: () => ({
+    content:
+      "You're not in plan mode, so there is nothing to exit — this tool does nothing here. " +
+      'Carry out the work directly with the file and command tools.',
+    is_error: true,
+  }),
+}

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -7,6 +7,8 @@ import { run_bash } from './run_bash.js'
 import { grep } from './grep.js'
 import { glob } from './glob.js'
 import { write_todos } from './write_todos.js'
+import { exit_plan_mode } from './exit_plan_mode.js'
+import type { PermissionMode } from '../permissions/policy.js'
 
 export const TOOLS: Tool[] = [
   edit_file as unknown as Tool,
@@ -16,7 +18,31 @@ export const TOOLS: Tool[] = [
   grep as unknown as Tool,
   glob as unknown as Tool,
   write_todos as unknown as Tool,
+  exit_plan_mode as unknown as Tool,
 ]
+
+/**
+ * What the agent may reach for while planning: everything that reads, the todo
+ * list so it can track its own research, run_bash (the loop narrows it to
+ * read-only commands), and the one tool that ends plan mode.
+ *
+ * Withholding the write tools from the schema is the first line of defence —
+ * a tool the model was never offered is one it mostly doesn't invent. The loop
+ * enforces the same set mechanically for when it does anyway.
+ */
+const PLAN_TOOL_NAMES = new Set([
+  'read_file', 'grep', 'glob', 'run_bash', 'write_todos', 'exit_plan_mode',
+])
+
+/**
+ * The tools to advertise for a permission mode. Outside plan mode
+ * exit_plan_mode is withheld: offering a model a way to "present a plan" when
+ * it is supposed to be doing the work invites it to stall.
+ */
+export function toolsForMode(mode: PermissionMode): Tool[] {
+  if (mode === 'plan') return TOOLS.filter((t) => PLAN_TOOL_NAMES.has(t.name))
+  return TOOLS.filter((t) => t.name !== 'exit_plan_mode')
+}
 
 export function getTool(name: string): Tool | undefined {
   return TOOLS.find((t) => t.name === name)

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -381,6 +381,7 @@ export function App() {
                 caret={caret}
                 disabled={agent.busy}
                 processingLabel={agent.processingLabel}
+                mode={agent.mode}
                 hint={
                   providerDown
                     ? 'provider unavailable — /provider to switch · /models to pick a model'

--- a/src/ui/CommandPalette.tsx
+++ b/src/ui/CommandPalette.tsx
@@ -1,5 +1,6 @@
 import { Box, Text } from 'ink'
 import { COMMANDS, type Command } from './constants.js'
+import { customCommands } from '../commands/custom.js'
 
 export type { Command }
 
@@ -8,8 +9,36 @@ interface Props {
   cursor: number
 }
 
+/**
+ * Everything `/` can complete to: the built-ins, then whatever Markdown files
+ * the project and the user have dropped in .miii/commands. Built-ins come first
+ * and a custom command may not shadow one — a repo that defines `/clear` should
+ * not be able to redefine what clearing the screen does.
+ */
+export function allCommands(): Command[] {
+  const builtin: Command[] = COMMANDS.map((c) => ({ ...c, origin: 'builtin' as const }))
+  const taken = new Set(builtin.map((c) => c.name))
+  const custom: Command[] = customCommands()
+    .filter((c) => !taken.has(c.name))
+    .map((c) => ({ name: c.name, description: c.description, origin: c.scope }))
+  return [...builtin, ...custom]
+}
+
+/**
+ * Commands whose name starts with what has been typed.
+ *
+ * Matched against the whole line, not just its first word: once you type a
+ * space the line has arguments and the palette should get out of the way, the
+ * same as it already does for `/copy last`. Resolving `/review src/a.ts` back
+ * to `/review` is the submit path's job, not the palette's — doing it here
+ * would leave the list open over your arguments and let tab overwrite them.
+ */
+export function filteredCommands(filter: string): Command[] {
+  return allCommands().filter((c) => c.name.startsWith(filter))
+}
+
 export function CommandPalette({ filter, cursor }: Props) {
-  const filtered = COMMANDS.filter((c) => c.name.startsWith(filter))
+  const filtered = filteredCommands(filter)
   if (filtered.length === 0) return null
 
   const nameWidth = Math.max(...filtered.map((c) => c.name.length))
@@ -30,6 +59,9 @@ export function CommandPalette({ filter, cursor }: Props) {
               {active ? '❯ ' : '  '}{cmd.name.padEnd(nameWidth)}
             </Text>
             <Text dimColor>{cmd.description}</Text>
+            {cmd.origin && cmd.origin !== 'builtin' && (
+              <Text color="cyan" dimColor>{cmd.origin}</Text>
+            )}
           </Box>
         )
       })}
@@ -38,8 +70,4 @@ export function CommandPalette({ filter, cursor }: Props) {
       </Box>
     </Box>
   )
-}
-
-export function filteredCommands(filter: string): Command[] {
-  return COMMANDS.filter((c) => c.name.startsWith(filter))
 }

--- a/src/ui/InputBar.tsx
+++ b/src/ui/InputBar.tsx
@@ -1,6 +1,7 @@
 import { memo, useEffect, useState } from 'react'
 import { Box, Text, useStdout } from 'ink'
 import { INPUT_PLACEHOLDER, INPUT_HINTS, BUSY_HINTS } from './constants.js'
+import { MODE_LABEL, type PermissionMode } from '../permissions/policy.js'
 
 interface Props {
   input: string
@@ -9,6 +10,20 @@ interface Props {
   processingLabel?: string
   /** Replaces the default key hints — used to surface a provider error. */
   hint?: string
+  /** Permission mode; anything but 'default' is shown, and colours the frame. */
+  mode?: PermissionMode
+}
+
+/**
+ * The frame colour carries the mode, so the state you are in is visible without
+ * reading anything. Red for bypass is the point: a session that never asks
+ * should not look like an ordinary one.
+ */
+const MODE_COLOR: Record<PermissionMode, string> = {
+  default: 'gray',
+  plan: 'cyan',
+  acceptEdits: 'green',
+  bypass: 'red',
 }
 
 const SPIN = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏']
@@ -88,6 +103,7 @@ export const InputBar = memo(function InputBar({
   disabled,
   processingLabel,
   hint,
+  mode = 'default',
 }: Props) {
   const [frame, setFrame] = useState(0)
   useEffect(() => {
@@ -111,7 +127,7 @@ export const InputBar = memo(function InputBar({
       <Box
         width="100%"
         borderStyle="round"
-        borderColor={disabled ? 'yellow' : 'gray'}
+        borderColor={disabled ? 'yellow' : MODE_COLOR[mode]}
         paddingX={1}
       >
         {disabled ? (
@@ -145,7 +161,17 @@ export const InputBar = memo(function InputBar({
         )}
       </Box>
       <Box paddingX={1}>
-        <Text dimColor>{fitHint(hint ?? (disabled ? BUSY_HINTS : INPUT_HINTS), stdout?.columns ?? 80)}</Text>
+        {mode !== 'default' && (
+          <Text color={MODE_COLOR[mode]} bold>{MODE_LABEL[mode]}{' · '}</Text>
+        )}
+        <Text dimColor>
+          {fitHint(
+            hint ?? (disabled ? BUSY_HINTS : INPUT_HINTS),
+            // The mode chip eats into the same row, so the hints have to fit
+            // what's left of it or the bar wraps and pushes the frame.
+            (stdout?.columns ?? 80) - (mode === 'default' ? 0 : MODE_LABEL[mode].length + 3),
+          )}
+        </Text>
       </Box>
     </Box>
   )

--- a/src/ui/PermissionPrompt.tsx
+++ b/src/ui/PermissionPrompt.tsx
@@ -24,7 +24,40 @@ function summarizeInput(input: unknown): string {
   return ''
 }
 
+/**
+ * Approving a plan, not a tool call.
+ *
+ * The plan itself is already on screen above (ToolBlock renders it in full), so
+ * this asks the one question left. "Yes, and stop asking about edits" is the
+ * honest second option: someone who has just read a whole plan and approved it
+ * does not want to re-approve each file it named.
+ */
+function PlanApproval({ cursor }: { cursor: number }) {
+  const options = [
+    'Yes — start working',
+    "Yes, and don't ask about file edits from here",
+    'No — keep planning, I want changes',
+  ]
+  return (
+    <Box flexDirection="column" marginBottom={1} borderStyle="round" borderColor="cyan" paddingX={1}>
+      <Text color="cyan" bold>Ready to start?</Text>
+      <Box marginTop={1}>
+        <Text dimColor>The plan above is what will happen. Nothing has been changed yet.</Text>
+      </Box>
+      <Box flexDirection="column" marginTop={1}>
+        {options.map((label, i) => (
+          <Text key={label} color={i === cursor ? 'cyan' : undefined}>
+            {i === cursor ? '❯ ' : '  '}
+            {i + 1}. {label}
+          </Text>
+        ))}
+      </Box>
+    </Box>
+  )
+}
+
 export function PermissionPrompt({ req, cursor }: { req: PermissionRequest; cursor: number }) {
+  if (req.toolName === 'exit_plan_mode') return <PlanApproval cursor={cursor} />
   const label = TOOL_LABEL[req.toolName] ?? req.toolName
   // The widest glob an "always" choice would persist. Showing it makes the blast
   // radius explicit — e.g. "npm run *" auto-allows every npm script, while a
@@ -33,7 +66,12 @@ export function PermissionPrompt({ req, cursor }: { req: PermissionRequest; curs
   const rule = widestPattern(req.toolName, subjectFor(req.toolName, req.input))
   const options = [
     { label: 'Yes', key: 'yes' },
-    { label: rule ? `Yes, don't ask again for ${rule}` : "Yes, don't ask again for this", key: 'always' },
+    {
+      // Naming the scope matters: the rule goes in the project's own
+      // .miii/permissions.json, so "don't ask again" means here, not everywhere.
+      label: rule ? `Yes, don't ask again for ${rule} (this project)` : "Yes, don't ask again in this project",
+      key: 'always',
+    },
     { label: 'No', key: 'no' },
   ]
   const summary = summarizeInput(req.input)

--- a/src/ui/ToolBlock.tsx
+++ b/src/ui/ToolBlock.tsx
@@ -3,6 +3,7 @@ import { highlight, supportsLanguage } from 'cli-highlight'
 import type { ToolUseDisplay, ToolResultDisplay } from './types.js'
 import { useToolExpanded } from './toolExpand.js'
 import { countLines, truncate } from './layout.js'
+import { renderMarkdown } from './markdown.js'
 
 // Tool output is collapsed to a few lines by default; a click or ctrl+o toggles full view.
 const COLLAPSED_LINES = 3
@@ -15,6 +16,7 @@ export const TOOL_LABEL: Record<string, string> = {
   glob: 'Glob',
   grep: 'Grep',
   write_todos: 'Todos',
+  exit_plan_mode: 'Plan',
 }
 
 // hljs language name keyed by file extension; undefined = render plain (no highlight).
@@ -244,7 +246,37 @@ function ToolResultBlock({ result, toolName }: { result: ToolResultDisplay; tool
   )
 }
 
+/**
+ * The proposed plan, rendered in full.
+ *
+ * Every other tool block collapses, because the user is skimming what the agent
+ * did. This one is the thing they are being asked to approve, so it never
+ * truncates and never hides behind ctrl+o — a plan you have to expand to read
+ * is a plan you approve without reading.
+ */
+function PlanBlock({ plan, result }: { plan: string; result?: ToolResultDisplay }) {
+  return (
+    <Box flexDirection="column" marginLeft={2}>
+      <Box borderStyle="round" borderColor="cyan" paddingX={1} flexDirection="column">
+        <Text color="cyan" bold>Proposed plan</Text>
+        <Box marginTop={1}>
+          <Text>{renderMarkdown(plan.trim())}</Text>
+        </Box>
+      </Box>
+      {result && (
+        <Text color={result.is_error ? 'yellow' : 'green'}>
+          {'⎿  '}{result.is_error ? 'kept planning' : 'approved — starting work'}
+        </Text>
+      )}
+    </Box>
+  )
+}
+
 export function ToolUseLine({ use, result }: { use: ToolUseDisplay; result?: ToolResultDisplay }) {
+  if (use.name === 'exit_plan_mode') {
+    const plan = (use.input as { plan?: string }).plan
+    if (typeof plan === 'string' && plan.trim()) return <PlanBlock plan={plan} result={result} />
+  }
   if (use.name === 'write_todos' && !result?.is_error) {
     const todos = (use.input as { todos?: TodoItem[] }).todos
     if (Array.isArray(todos) && todos.length > 0) return <TodoBlock todos={todos} />

--- a/src/ui/constants.ts
+++ b/src/ui/constants.ts
@@ -3,6 +3,12 @@
 export interface Command {
   name: string
   description: string
+  /**
+   * Where the command came from. Built-ins are the ones below; the others are
+   * Markdown files under .miii/commands, and the palette dims their origin so
+   * you can tell a repo's command from your own.
+   */
+  origin?: 'builtin' | 'project' | 'user'
 }
 
 /**
@@ -11,18 +17,20 @@ export interface Command {
  * description edited here updates both.
  */
 export const COMMANDS: Command[] = [
+  { name: '/plan',   description: 'plan first — research read-only, then approve the plan' },
   { name: '/models', description: 'pick model · tab to change provider · ←→ effort' },
   { name: '/provider', description: 'open provider picker (configured in ~/.miii/config.json)' },
   { name: '/new',    description: 'save current session and start fresh' },
   { name: '/sessions', description: 'list sessions and resume one' },
   { name: '/copy',   description: 'copy to clipboard · /copy last | code | tool | all' },
   { name: '/compact', description: 'summarize the conversation to free context · /compact <focus>' },
+  { name: '/permissions', description: 'list saved approval rules and where they live' },
   { name: '/clear',  description: 'clear chat and reset context' },
   { name: '/exit',   description: 'quit miii' },
 ]
 
 /** Commands featured on the welcome card, in display order. */
-const WELCOME_COMMAND_NAMES = ['/models', '/sessions', '/new', '/copy', '/compact', '/clear']
+const WELCOME_COMMAND_NAMES = ['/plan', '/models', '/sessions', '/compact', '/clear']
 
 /** The featured commands, resolved against COMMANDS so copy never drifts. */
 export const WELCOME_COMMANDS: Command[] = WELCOME_COMMAND_NAMES.flatMap(
@@ -35,7 +43,7 @@ export const WELCOME_PROMPT = 'To get started, describe a task or try one of the
 export const INPUT_PLACEHOLDER = 'describe a task, or type / for commands'
 
 /** Key hints under the input bar. Kept short — they share one line. */
-export const INPUT_HINTS = '⏎ send · / commands · @ file · ctrl+y copy · ctrl+s select · scroll or pgup/pgdn to look back'
+export const INPUT_HINTS = '⏎ send · / commands · @ file · shift+tab mode · ctrl+y copy · ctrl+s select · pgup/pgdn to look back'
 
 /** Key hints under the input bar while a turn is running. */
 export const BUSY_HINTS = 'esc interrupt · click or ctrl+o expand tool output · ctrl+y copy · scroll to look back'

--- a/src/ui/hooks/useAgentRunner.ts
+++ b/src/ui/hooks/useAgentRunner.ts
@@ -9,6 +9,7 @@ import { runAgent } from '../../agent/loop.js'
 import { compactHistory, estimateHistoryTokens } from '../../agent/compact.js'
 import type { ChatMessage, PermissionRequest, PermissionAnswer, ToolUseDisplay, ToolResultDisplay } from '../types.js'
 import type { MiiMessage } from '../../agent/types.js'
+import { MODE_HINT, MODE_LABEL, nextMode, type PermissionMode } from '../../permissions/policy.js'
 import { tailLine } from '../layout.js'
 
 // How often (ms) we flush streaming text to React state — avoids a re-render per token.
@@ -36,10 +37,37 @@ export function useAgentRunner(model: string | undefined, activeCtx: number | nu
    */
   const [usedTokens, setUsedTokens] = useState(0)
   const [compacting, setCompacting] = useState(false)
+  /**
+   * Permission mode. Held here rather than in App because the loop can change
+   * it mid-run (the user approving a plan), and this is where that event lands.
+   */
+  const [mode, setModeState] = useState<PermissionMode>('default')
 
   const busyRef = useRef(false)
+  /**
+   * Mirror of `mode` for the async send path. `sendMessage` captures the mode
+   * at the moment it starts; reading the ref means a run always begins from the
+   * mode the user can currently see, not one a render behind.
+   */
+  const modeRef = useRef<PermissionMode>(mode)
+  modeRef.current = mode
   const abortRef = useRef<AbortController | null>(null)
   const pendingPermissionRef = useRef<PermissionRequest | null>(null)
+
+  /** Set the permission mode and describe the change in the transcript. */
+  function setMode(next: PermissionMode) {
+    modeRef.current = next
+    setModeState(next)
+    return next
+  }
+
+  /**
+   * shift+tab — step to the next mode, returning it so the caller can say so.
+   * The notice belongs to App, which owns that strip of the screen.
+   */
+  function cycleMode(): PermissionMode {
+    return setMode(nextMode(modeRef.current))
+  }
 
   /** Prompt the UI for a permission decision and await the user's choice. */
   function askPermission(toolName: string, input: unknown): Promise<PermissionAnswer> {
@@ -147,6 +175,7 @@ export function useAgentRunner(model: string | undefined, activeCtx: number | nu
         userText: text,
         images,
         permissions: { ask: askPermission },
+        mode: modeRef.current,
         signal: controller.signal,
         num_ctx: activeCtx ?? undefined,
       })
@@ -189,6 +218,20 @@ export function useAgentRunner(model: string | undefined, activeCtx: number | nu
             })
             setActiveToolResults([...turnResults])
             setProcessingLabel('crunching…')
+            break
+          }
+          case 'mode-change': {
+            // The loop, not the user, moved the mode — approving a plan leaves
+            // plan mode. Mirror it so the indicator matches what the agent can
+            // actually do from here, and note it in the transcript.
+            setMode(ev.mode)
+            setMessages((prev) => [
+              ...prev,
+              {
+                role: 'assistant',
+                content: `▸ **plan approved** — ${MODE_LABEL[ev.mode]}: ${MODE_HINT[ev.mode]}`,
+              },
+            ])
             break
           }
           case 'turn-end': {
@@ -324,10 +367,12 @@ export function useAgentRunner(model: string | undefined, activeCtx: number | nu
     activeToolResults, setActiveToolResults,
     usedTokens, setUsedTokens,
     compacting,
+    mode, setMode, cycleMode,
     // refs (for keyboard handler)
     busyRef,
     abortRef,
     pendingPermissionRef,
+    modeRef,
     // actions
     sendMessage,
     resolvePermission,

--- a/src/ui/hooks/useKeyboard.ts
+++ b/src/ui/hooks/useKeyboard.ts
@@ -28,6 +28,8 @@ import {
   type SessionMeta,
 } from '../../session/store.js'
 import { estimateHistoryTokens } from '../../agent/compact.js'
+import { loadScopedRules, MODE_HINT, MODE_LABEL, type PermissionMode } from '../../permissions/policy.js'
+import { expandCommand, findCustomCommand, invalidateCustomCommands } from '../../commands/custom.js'
 import type { useAgentRunner } from './useAgentRunner.js'
 
 const EFFORTS: Effort[] = ['low', 'medium', 'high']
@@ -214,6 +216,7 @@ export function useKeyboard(opts: KeyboardOptions) {
     busyRef, abortRef,
     sendMessage, compact, messages, agentHistory, setMessages, setAgentHistory, setStreamingContent, setThinkingTail,
     setActiveToolUses, setActiveToolResults, setError, setUsedTokens,
+    setMode, cycleMode, modeRef,
   } = agent
 
   const { write } = useStdout()
@@ -266,6 +269,47 @@ export function useKeyboard(opts: KeyboardOptions) {
   }
 
   const effort: Effort = cfg.effort ?? 'medium'
+
+  /**
+   * Resolve a submitted line to a custom command plus its argument string.
+   * Returns null for anything that isn't one, so the caller can fall through to
+   * treating the line as an ordinary message.
+   */
+  function customCommandFor(line: string) {
+    if (!line.startsWith('/')) return null
+    const name = line.split(/\s/)[0]
+    const command = findCustomCommand(name)
+    return command ? { command, args: line.slice(name.length) } : null
+  }
+
+  /** Announce a mode the user just moved to. */
+  function noticeMode(mode: PermissionMode) {
+    setNotice(`${MODE_LABEL[mode]} — ${MODE_HINT[mode]}`)
+  }
+
+  /**
+   * Print the saved approval rules into the transcript, grouped by where they
+   * live. Answers the question the permission prompt raises and never closes:
+   * what have I already agreed to, and does it follow me to my next project?
+   */
+  function showPermissions() {
+    const sections = (['project', 'user'] as const).map((scope) => {
+      const rules = loadScopedRules(scope)
+      const where = scope === 'project' ? '`.miii/permissions.json` (this project)' : '`~/.miii/permissions.json` (every project)'
+      if (!rules.length) return `**${scope}** — ${where}\n\nnothing saved yet.`
+      const lines = rules.map((r) => `- \`${r.tool}\` → \`${r.pattern}\``).join('\n')
+      return `**${scope}** — ${where}\n\n${lines}`
+    })
+    setMessages((prev) => [
+      ...prev,
+      {
+        role: 'assistant',
+        content:
+          `⚖ **approval rules**\n\n${sections.join('\n\n')}\n\n` +
+          'Delete a rule by editing the file. "Yes, don\'t ask again" writes to the project file.',
+      },
+    ])
+  }
 
   useInput((char, key) => {
     // --- mouse ---
@@ -449,6 +493,16 @@ export function useKeyboard(opts: KeyboardOptions) {
     if (state === 'ready') {
       if (busyRef.current) return
 
+      // shift+tab cycles the permission mode. Handled before the palette's tab
+      // completion below, which matches on key.tab alone and would otherwise
+      // swallow it whenever the input happens to start with '/'. Only while
+      // idle: the running turn captured its mode when it started, so changing
+      // it mid-run would show a mode the agent is not actually operating under.
+      if (key.tab && key.shift) {
+        noticeMode(cycleMode())
+        return
+      }
+
       // Ctrl+V — paste an image off the OS clipboard (Cmd+V only pastes text, so
       // a copied screenshot needs an explicit reader). Inserts an image chip.
       if (key.ctrl && char === 'v') {
@@ -467,6 +521,9 @@ export function useKeyboard(opts: KeyboardOptions) {
       // typing the '@' that opens a mention drops the file cache, so a picker
       // opened just after creating a file still lists it.
       if (char === '@') invalidateFileCache()
+      // Same idea for '/': a command file written a moment ago should show up
+      // in the palette that is about to open, not on the next launch.
+      if (char === '/') invalidateCustomCommands()
       const mention = !paletteOpen ? parseMention(input) : null
       const fileMatches = mention ? searchFiles(process.cwd(), mention.query) : []
       const fileOpen = mention !== null && fileMatches.length > 0
@@ -530,6 +587,10 @@ export function useKeyboard(opts: KeyboardOptions) {
         // the reply is visible as it arrives.
         scrollToBottom()
         const trimmed = input.trim()
+        // Resolved once, up front: the built-in chain below tests it as a
+        // condition and then uses it, and looking it up twice re-reads the
+        // command directory on every send.
+        const custom = customCommandFor(trimmed)
         pushHistory(trimmed)
         historyIndex = -1
         historyDraft = ''
@@ -567,6 +628,14 @@ export function useKeyboard(opts: KeyboardOptions) {
           setSessions(listSessions())
           setCursor(() => 0)
           setState('sessions')
+        } else if (trimmed === '/plan') {
+          // Explicit way in, for people who haven't found shift+tab. Toggles,
+          // so the same key gets you back out of a plan you no longer want.
+          const next: PermissionMode = modeRef.current === 'plan' ? 'default' : 'plan'
+          setMode(next)
+          noticeMode(next)
+        } else if (trimmed === '/permissions') {
+          showPermissions()
         } else if (trimmed === '/exit') {
           exit()
         } else if (trimmed.startsWith('/provider ')) {
@@ -578,6 +647,12 @@ export function useKeyboard(opts: KeyboardOptions) {
           } else {
             setNotice(`unknown provider "${p}" — configured: ${names.join(', ')}`)
           }
+        } else if (custom) {
+          // A Markdown file under .miii/commands. Its body becomes the prompt,
+          // so from here on it is an ordinary turn — which is the point: a
+          // custom command is a saved message, not a new kind of thing.
+          setNotice(null)
+          sendMessage(expandCommand(custom.command.body, custom.args))
         } else if (trimmed) {
           setNotice(null)
           // Pull any image chips out of the text, gathering their base64 bytes

--- a/src/ui/palette.test.ts
+++ b/src/ui/palette.test.ts
@@ -1,0 +1,32 @@
+/**
+ * The palette's matching rule. Narrow, but it guards a real trap: matching on
+ * the command word instead of the whole line leaves the list open over your
+ * arguments, where tab-completion then overwrites them.
+ */
+import { describe, it, expect } from 'vitest'
+import { filteredCommands, allCommands } from './CommandPalette.js'
+
+describe('command palette', () => {
+  it('offers the built-ins', () => {
+    const names = allCommands().map((c) => c.name)
+    expect(names).toContain('/plan')
+    expect(names).toContain('/permissions')
+    expect(names.every((n) => n.startsWith('/'))).toBe(true)
+  })
+
+  it('marks every built-in as such', () => {
+    expect(allCommands().some((c) => c.origin === 'builtin')).toBe(true)
+  })
+
+  it('narrows by prefix', () => {
+    expect(filteredCommands('/pl').map((c) => c.name)).toEqual(['/plan'])
+    expect(filteredCommands('/zzz')).toEqual([])
+  })
+
+  it('closes once the line has arguments', () => {
+    // `/copy last` and `/compact <focus>` both take arguments; the palette must
+    // stop matching so tab cannot replace the line with the bare command name.
+    expect(filteredCommands('/copy last')).toEqual([])
+    expect(filteredCommands('/compact just the bug')).toEqual([])
+  })
+})


### PR DESCRIPTION
Plan mode (shift+tab or /plan) makes the session read-only: miii researches, proposes a plan, and touches nothing until you approve it. Enforced in three layers rather than asked for in the prompt, since a small model that has seen edit_file earlier in the transcript will call it regardless — toolsForMode withholds the write tools from the schema, planGuard blocks them in the loop, and run_bash is narrowed to commands that only report. A compound command is refused however harmless its first token, the same command-boundary rule that stops a wildcard permission rule spanning a &&.

exit_plan_mode is put to the user directly rather than through check(): an "always" persisted as a permission rule would auto-approve every future plan, making plan mode a no-op forever after. Approval flips the loop's live mode, which rebuilds the advertised tools and the system prompt each turn, and emits mode-change so the UI never trails a turn behind.

shift+tab cycles normal -> plan -> auto-accept edits -> bypass, and the input frame takes the mode's colour.

Permission rules now default to .miii/permissions.json in the project. They were global, which was wrong for the common case: a subject like "src/index.ts" is project-relative, so approving it once auto-allowed that path in every repo opened afterwards. ~/.miii/permissions.json is still read and still applies everywhere. /permissions lists both and names the file each rule came from.

Custom slash commands: a Markdown file under .miii/commands is a command, with frontmatter descriptions and $ARGUMENTS / $1..$9 substitution. Project scope shadows user scope; neither can shadow a built-in.

Verified end to end against a real model, which tried to escape plan mode with a heredoc redirect and then sed -i — both refused, file unchanged — and then completed research -> plan -> approve -> edit on the approval path.